### PR TITLE
make start and endts optional in slam

### DIFF
--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -20,6 +20,10 @@ $ annoutil projects
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2] - 2020-09-01
+### Changed
+- SLAM - startTs and endTs not optional in Slam request
+
 ## [0.3.1] - 2020-07-16
 ### Changed
 - If the upload of point clouds or images crashes and returns status code 429, 408 or 5xx the script will

--- a/annotell-input-api/annotell/input_api/__init__.py
+++ b/annotell-input-api/annotell/input_api/__init__.py
@@ -3,4 +3,4 @@ from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/annotell-input-api/annotell/input_api/input_api_model.py
+++ b/annotell-input-api/annotell/input_api/input_api_model.py
@@ -248,9 +248,14 @@ class TimeSpecification(RequestCall):
         self.time_calibration = time_calibration
 
     def to_dict(self) -> dict:
-        as_dict = dict(startTs=self.start_ts,
-                       endTs=self.end_ts,
-                       timeCalibration=self.time_calibration.to_dict())
+        
+        as_dict = dict(timeCalibration=self.time_calibration.to_dict())
+            
+        if self.start_ts:
+            as_dict["startTs"] = self.start_ts
+        if self.end_ts:
+            as_dict["endTs"] = self.end_ts
+        
 
         return as_dict
 


### PR DESCRIPTION
Slam producer no longer requires startTs and endTs.
Change them into optional