### PR TITLE
add support for supplying project and batch

### DIFF
--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -20,6 +20,14 @@ $ annoutil projects
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.5] - 2020-10-19
+### Added
+- Add support for `project` and `batch` identifiers for input request. 
+    Specifying project and batch adds input to specified batch.
+    When only sending project, inputs are added to the latest open batch for the project. 
+### Deprecated
+- `input_list_id` will be removed in the 0.4.x version
+
 ## [0.3.4] - 2020-09-10
 ### Changed
 - SLAM - add required `sub_sequence_id` and optional `settings`

--- a/annotell-input-api/annotell/input_api/__init__.py
+++ b/annotell-input-api/annotell/input_api/__init__.py
@@ -3,4 +3,4 @@ from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/annotell-input-api/annotell/input_api/annoutil.py
+++ b/annotell-input-api/annotell/input_api/annoutil.py
@@ -7,7 +7,6 @@ import click
 
 client = InputApiClient(auth=None)
 
-
 def _tabulate(body, headers, title=None):
     tab = tabulate(
         body,
@@ -55,19 +54,19 @@ def projects(project_id, get_requests, get_input_lists):
         tab = _get_table(list_of_input_lists, headers, "INPUTLISTS")
         print(tab)
     elif get_requests and project_id:
-        headers = ["id", "created", "project_id", "title", "description", "input_list_id"]
+        headers = ["id", "created", "project_id", "title", "description", "input_list_id", "input_batch_id", "external_id"]
         list_of_requests = client.get_requests_for_project_id(project_id=project_id)
         tab = _get_table(list_of_requests, headers, "REQUESTS")
         print(tab)
     elif project_id:
         list_of_projects = client.list_projects()
         target_project = [p for p in list_of_projects if p.id == project_id]
-        headers = ["id", "created", "title", "description", "deadline", "status"]
+        headers = ["id", "created", "title", "description", "deadline", "status", "external_id"]
         tab = _get_table(target_project, headers, "PROJECTS")
         print(tab)
     else:
         list_of_projects = client.list_projects()
-        headers = ["id", "created", "title", "description", "deadline", "status"]
+        headers = ["id", "created", "title", "description", "deadline", "status", "external_id"]
         tab = _get_table(list_of_projects, headers, "PROJECTS")
         print(tab)
 
@@ -192,7 +191,7 @@ def calibration_externalid(external_id):
 @click.argument('request_ids', nargs=-1)
 @click.command()
 def requests(request_ids):
-    headers = ["id", "created", "project_id", "title", "description", "input_list_id"]
+    headers = ["id", "created", "project_id", "title", "description", "input_list_id", "input_batch_id", "external_id"]
     request_ids_list = [int(rid) for rid in request_ids]
     dict_of_requests = client.get_requests_for_request_ids(
         request_ids=request_ids_list
@@ -213,6 +212,16 @@ def input_lists(input_list_id, get_requests):
         tab = _get_table(list_of_requests, headers, "REQUESTS")
         print(tab)
 
+@click.command(name="batches")
+@click.argument('project', nargs=1, type=str, default=None, required=False)
+def input_batch(project):
+    print()
+    if project:
+        headers = ["external_id", "title",  "status", "created", "updated"]
+        list_of_batches = client.list_project_batches(project)
+        tab = _get_table(list_of_batches, headers, "BATCHES")
+        print(tab)
+
 
 cli.add_command(projects)
 cli.add_command(inputs)
@@ -221,6 +230,7 @@ cli.add_command(calibration)
 cli.add_command(calibration_externalid)
 cli.add_command(requests)
 cli.add_command(input_lists)
+cli.add_command(input_batch)
 
 
 def main():

--- a/annotell-input-api/annotell/input_api/input_api_model.py
+++ b/annotell-input-api/annotell/input_api/input_api_model.py
@@ -22,6 +22,13 @@ class InvalidatedReasonInput(str, Enum):
     DUPLICATE = "duplicate"
     INCORRECTLY_CREATED = "incorrectly-created"
 
+class InputBatchStatus(str, Enum):
+    CREATED = 'created'
+    OPEN = 'open'
+    READY = 'ready'
+    INPROGESS = 'in-progress'
+    COMPLETED = 'completed'
+
 #
 # Request Calls
 #
@@ -413,21 +420,47 @@ class InputList(Response):
             f"name={self.name}, " + \
             f"created={self.created})>"
 
+class InputBatch(Response):
+    def __init__(self, id: int, project_id: int, external_id: str, title: str, status: InputBatchStatus,  created: datetime, updated: datetime):
+        self.id = id
+        self.project_id = project_id
+        self.external_id = external_id
+        self.title = title
+        self.status = status
+        self.created = created
+        self.updated = updated
+
+    @staticmethod
+    def from_json(js: dict):
+        return InputBatch(int(js["id"]), int(js["projectId"]), js["externalId"], js["title"], js["status"],
+                         ts_to_dt(js["created"]), ts_to_dt(js["created"]))
+
+    def __repr__(self):
+        return f"<InputBatch(" + \
+            f"id={self.id}, " + \
+            f"project_id={self.project_id}, " + \
+            f"external_id={self.external_id}, " + \
+            f"title={self.title}, " + \
+            f"status={self.status}, " + \
+            f"created={self.created}, " + \
+            f"updated={self.updated})>"
+
 
 class Project(Response):
     def __init__(self, id: int, created: datetime, title: str, description: str,
-                 deadline: Optional[str], status: str):
+                 deadline: Optional[str], status: str, external_id: str):
         self.id = id
         self.created = created
         self.title = title
         self.description = description
         self.deadline = deadline
         self.status = status
+        self.external_id = external_id
 
     @staticmethod
     def from_json(js: dict):
         return Project(int(js["id"]), ts_to_dt(js["created"]), js["title"],
-                       js["description"], js.get("deadline"), js["status"])
+                       js["description"], js.get("deadline"), js["status"], js["externalId"])
 
     def __repr__(self):
         return f"<Project(" + \
@@ -436,23 +469,26 @@ class Project(Response):
             f"title={self.title}, " + \
             f"description={self.description}, " + \
             f"deadline={self.deadline}, " + \
-            f"status={self.status})>"
+            f"status={self.status}, " + \
+            f"external_id={self.external_id})>"
 
 
 class Request(Response):
     def __init__(self, id: int, created: datetime, project_id: int, title: str, description: str,
-                 input_list_id: int):
+                 input_list_id: int, input_batch_id: int, external_id: str):
         self.id = id
         self.created = created
         self.project_id = project_id
         self.title = title
         self.description = description
         self.input_list_id = input_list_id
+        self.input_batch_id = input_batch_id
+        self.external_id = external_id
 
     @staticmethod
     def from_json(js: dict):
         return Request(int(js["id"]), ts_to_dt(js["created"]), int(js["projectId"]),
-                       js["title"], js["description"], int(js["inputListId"]))
+                       js["title"], js["description"], int(js["inputListId"]), int(js["inputBatchId"]), js["externalId"])
 
     def __repr__(self):
         return f"<Request(" + \
@@ -461,7 +497,9 @@ class Request(Response):
             f"project_id={self.project_id}, " + \
             f"title={self.title}, " + \
             f"description={self.description}, " + \
-            f"input_list_id={self.input_list_id})>"
+            f"input_list_id={self.input_list_id}, " + \
+            f"input_batch_id={self.input_batch_id}, " + \
+            f"external_id={self.external_id})>"
 
 
 class ExportAnnotation(Response):


### PR DESCRIPTION
Implement changes from Input API, allowing inputs to be created via `project` and `batch` identifiers. 

`input_list_id` is supported for the time being, but will be removed in a future release. 

new routes for inputs will be 
`POST inputs/project/{projectIdentifier}/images` -> add to latest open batch
`POST inputs/project/{projectIdentifier}/batch/{batchIdentifier}/images` add to specified batch