### PR TITLE
V0 clean up

### DIFF
--- a/annotell-input-api/.gitignore
+++ b/annotell-input-api/.gitignore
@@ -1,0 +1,2 @@
+# for pre-deploy tests
+test/**

--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -13,7 +13,7 @@ https://annotell.github.io/annotell-python/docs/
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] - 2021-01-27
+## [0.4.0] - 2021-01-28
 
 ### Changed
 

--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -5,22 +5,46 @@ Python 3 library providing access to Annotell Input API
 To install with pip run `pip install annotell-input-api`
 
 # Documentation
+
 All available documentation for the Annotell Input API Client can be found here:
 https://annotell.github.io/annotell-python/docs/
 
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-## [0.3.12] - 2021-01-13
+## [0.3.13] - 20201-01-22
+
 ### Changed
+
+- Renamed method `upload_and_create_images_input_job` to `create_inputs_images`.
+- Renamed method `list_projects` to `get_projects`.
+- Renamed method `list_project_batches` to `get_project_batches`.
+- Changed behaviour of method `download_annotations`. The previously optional argumnet `request_id` has been removed. Additionally, the return
+  signature is changed to return a list of annotations for each input, instead of a dict as before.
+- Behaviour of `get_inputs` has changed. It now receives `project` (identifier, not numerical id anymore), as well as two optional parameters `batch` and `include_invalidated`. Returns all inputs belonging to the project, with the option of filtering on batch and whether or not including invalidated inputs. The returned list of classes had additional fields describing which batch each input belongs to, as well as their status (`created`, `processing`, `failed`, `invalidated`).
+- Changed name of argument `input_ids` to `input_internal_ids` for method `invalidate_inputs`.
+
+### Removed
+
+- Methods `count_inputs_for_external_ids`, `mend_input_data`, `remove_inputs_from_input_list`, `list_input_lists`, `publish_batch`, `get_requests_for_request_ids`, `get_requests_for_input_lists`, `get_input_status`, `get_input_jobs_status`, `get_requests_for_project_id`, `get_datas_for_inputs_by_internal_ids` and `get_datas_for_inputs_by_external_ids` have all been removed.
+
+## [0.3.12] - 2021-01-13
+
+### Changed
+
 - Removed getting started documentation from README.md and instead link to new docs.
 
 ## [0.3.11] - 2020-12-14
+
 ### Changed
+
 - Deserialization bugfix in models for `InputBatch` and `InputBatch`.
 
 ## [0.3.10] - 2020-12-01
+
 ### Added
+
 - Minor fix in annoutil
 
 ## [0.3.9] - 2020-11-26

--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -13,7 +13,7 @@ https://annotell.github.io/annotell-python/docs/
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.13] - 20201-01-22
+## [0.4.0] - 2021-01-27
 
 ### Changed
 
@@ -22,18 +22,20 @@ All notable changes to this project will be documented in this file.
 - Renamed method `list_project_batches` to `get_project_batches`.
 - Changed behaviour of method `download_annotations`. The previously optional argumnet `request_id` has been removed. Additionally, the return
   signature is changed to return a list of annotations for each input, instead of a dict as before.
-- Behaviour of `get_inputs` has changed. It now receives `project` (identifier, not numerical id anymore), as well as two optional parameters `batch` and `include_invalidated`. Returns all inputs belonging to the project, with the option of filtering on batch and whether or not including invalidated inputs. The returned list of classes had additional fields describing which batch each input belongs to, as well as their status (`created`, `processing`, `failed`, `invalidated`).
+- Behaviour of `get_inputs` has changed. It now receives `project` (identifier, not numerical id anymore), as well as three optional parameters `batch`, `external_ids` and `include_invalidated`. Returns all inputs belonging to the project, with the option of filtering on batch, external ID and whether or not including invalidated inputs. The returned list of classes had additional fields describing which batch each input belongs to, as well as their status (`created`, `processing`, `failed`, `invalidated`).
 - Changed name of argument `input_ids` to `input_internal_ids` for method `invalidate_inputs`.
+- Use backport of `dataclasses` to support python 3.6. 
+- Add missing dependency on `python-dateutil`.
 
 ### Removed
 
-- Methods `count_inputs_for_external_ids`, `mend_input_data`, `remove_inputs_from_input_list`, `list_input_lists`, `publish_batch`, `get_requests_for_request_ids`, `get_requests_for_input_lists`, `get_input_status`, `get_input_jobs_status`, `get_requests_for_project_id`, `get_datas_for_inputs_by_internal_ids` and `get_datas_for_inputs_by_external_ids` have all been removed.
+- Methods `count_inputs_for_external_ids`, `get_internal_ids_for_external_ids`, `mend_input_data`, `remove_inputs_from_input_list`, `list_input_lists`, `publish_batch`, `get_requests_for_request_ids`, `get_requests_for_input_lists`, `get_input_status`, `get_input_jobs_status`, `get_requests_for_project_id`, `get_datas_for_inputs_by_internal_ids` and `get_datas_for_inputs_by_external_ids` have all been removed.
 
 ## [0.3.12] - 2021-01-13
 
 ### Changed
 
-- Removed getting started documentation from README.md and instead link to new docs.
+- Removed getting started documentation from `README.md` and instead link to new docs.
 
 ## [0.3.11] - 2020-12-14
 

--- a/annotell-input-api/annotell/input_api/__init__.py
+++ b/annotell-input-api/annotell/input_api/__init__.py
@@ -3,4 +3,4 @@ from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.3.12"
+__version__ = "0.4.0"

--- a/annotell-input-api/annotell/input_api/annoutil.py
+++ b/annotell-input-api/annotell/input_api/annoutil.py
@@ -14,8 +14,7 @@ if env:
 else:
     org_id = None
 
-# client = InputApiClient(auth=None, client_organization_id=org_id)
-client = create_input_api_client(env="development", client_organization_id=3)
+client = InputApiClient(auth=None, client_organization_id=org_id)
 
 
 def _tabulate(body, headers, title=None):

--- a/annotell-input-api/annotell/input_api/annoutil.py
+++ b/annotell-input-api/annotell/input_api/annoutil.py
@@ -1,6 +1,8 @@
+from annotell.apiclients.input_api_client import create_input_api_client
 from typing import Optional, List
 from tabulate import tabulate
 from .input_api_client import InputApiClient
+from pprint import pprint
 
 import click
 import os
@@ -12,7 +14,8 @@ if env:
 else:
     org_id = None
 
-client = InputApiClient(auth=None, client_organization_id=org_id)
+# client = InputApiClient(auth=None, client_organization_id=org_id)
+client = create_input_api_client(env="development", client_organization_id=3)
 
 
 def _tabulate(body, headers, title=None):
@@ -51,18 +54,18 @@ def cli():
 
 
 @click.command()
-@click.argument('project_external_id', nargs=1, default=None, required=False, type=str)
+@click.argument('project', nargs=1, default=None, required=False, type=str)
 @click.option('--get-batches', is_flag=True)
-def projects(project_external_id, get_batches):
+def projects(project, get_batches):
     print()
-    if project_external_id and get_batches:
-        list_of_input_batches = client.get_project_batches(project_external_id)
+    if project and get_batches:
+        list_of_input_batches = client.get_project_batches(project)
         headers = ["external_id", "title", "status", "created", "updated"]
         tab = _get_table(list_of_input_batches, headers, "BATCHES")
         print(tab)
-    elif project_external_id:
+    elif project:
         list_of_projects = client.get_projects()
-        target_project = [p for p in list_of_projects if p.external_id == project_external_id]
+        target_project = [p for p in list_of_projects if p.external_id == project]
         headers = ["created", "title", "description", "deadline", "status", "external_id"]
         tab = _get_table(target_project, headers, "PROJECTS")
         print(tab)
@@ -74,16 +77,16 @@ def projects(project_external_id, get_batches):
 
 
 @click.command()
-@click.argument("internal_ids", nargs=-1, required=True)
+@click.argument('project', nargs=1, default=None, required=True, type=str)
+@click.option('--batch', nargs=1, default=None, required=False, type=str)
+@click.option('--external-ids', required=False, multiple=True)
+@click.option('--include-invalidated', required=False, is_flag=True)
 @click.option("--view", is_flag=True)
-@click.option("--get-export-status", is_flag=True)
-@click.option("--get-upload-status", is_flag=True)
-@click.option("--get-input-lists", is_flag=True)
-@click.option("--get-datas", is_flag=True)
-def inputs(internal_ids, view, get_export_status, get_upload_status, get_input_lists, get_datas):
+def inputs(project, batch, external_ids, include_invalidated, view):
     print()
-    if internal_ids and view:
-        view_dict = client.get_view_links(list(internal_ids))
+    if view:
+        inputs = client.get_inputs(project, batch, external_ids=external_ids, include_invalidated=include_invalidated)
+        view_dict = client.get_view_links([input.internal_id for input in inputs])
         body = []
         headers = ["internal_id", "view_link"]
         for internal_id, link in view_dict.items():
@@ -92,151 +95,58 @@ def inputs(internal_ids, view, get_export_status, get_upload_status, get_input_l
             ])
         tab = _tabulate(body, headers, title="VIEW LINKS FOR INPUTS")
         print(tab)
-    elif internal_ids and get_export_status:
-        status_dict = client.get_input_status(list(internal_ids))
-        body = []
-        headers = ["internal_id", "request_id", "export_ready"]
-        for (internal_id, requests_status) in status_dict.items():
-            for (request_id, status) in requests_status.items():
-                body.append([internal_id, request_id, status])
-        tab = _tabulate(body, headers, title="EXPORT STATUS FOR INPUTS")
-        print(tab)
-    elif internal_ids and get_upload_status:
-        list_of_jobs = client.get_input_jobs_status(internal_ids=list(internal_ids))
-        headers = ["id", "internal_id", "external_id",
-                   "filename", "status", "added", "error_message"]
-        tab = _get_table(list_of_jobs, headers, "UPLOAD STATUS FOR INPUTS")
-        print(tab)
-
-    elif internal_ids and get_input_lists:
-        dict_of_lists = client.get_input_lists_for_inputs(list(internal_ids))
-        body = [[k, v] for k, v in dict_of_lists.items()]
-        headers = ["internal_id", "input_list"]
-        tab = _tabulate(body, headers, "INPUT LISTS FOR INPUTS")
-        print(tab)
-
-    elif internal_ids and get_datas:
-        dict_of_datas = client.get_datas_for_inputs_by_internal_ids(internal_ids)
-        headers = ["input", "datas"]
-        padded_body = []
-        for (input_obj, datas) in dict_of_datas.items():
-            padded_body.append([input_obj, datas[0]])
-            for data in datas[1:]:
-                padded_body.append(["", data])
-        tab = _tabulate(padded_body, headers, "DATAS IN INPUTS")
-        print(tab)
-
-
-@click.command(name="inputs-externalid")
-@click.argument("external_ids", nargs=-1, required=True)
-@click.option("--get-upload-status", is_flag=True)
-@click.option("--get-datas", is_flag=True)
-def inputs_externalid(external_ids, get_upload_status, get_datas):
-    print()
-    if external_ids and get_upload_status:
-        headers = ["id", "internal_id", "external_id",
-                   "filename", "status", "added", "error_message"]
-        list_of_jobs = client.get_input_jobs_status(external_ids=list(external_ids))
-        tab = _get_table(list_of_jobs, headers, title="UPLOAD STATUS FOR INPUTS")
-        print(tab)
-    elif external_ids and get_datas:
-        dict_of_datas = client.get_datas_for_inputs_by_external_ids(external_ids)
-        headers = ["input", "datas"]
-        padded_body = []
-        for (input_obj, datas) in dict_of_datas.items():
-            padded_body.append([input_obj, datas[0]])
-            for data in datas[1:]:
-                padded_body.append(["", data])
-        tab = _tabulate(padded_body, headers, "DATAS IN INPUTS")
-        print(tab)
-
     else:
-        to_internal_dict = client.get_internal_ids_for_external_ids(list(external_ids))
-        body = []
-        headers = ["external_id", "internal_id"]
-        for external_id, internal_ids in to_internal_dict.items():
-            for internal_id in internal_ids:
-                body.append(
-                    [external_id, internal_id]
-                )
-        tab = _tabulate(body, headers, title="EXTERNAL IDS TO INTERNAL IDS")
+        inputs = client.get_inputs(project, batch, include_invalidated=include_invalidated)
+        headers = ["internal_id",
+                   "external_id",
+                   "batch",
+                   "input_type",
+                   "status",
+                   "error_message"]
+        tab = _get_table(inputs, headers, "INPUTS")
         print(tab)
 
 
 @click.command()
-@click.argument('id', nargs=1, default=None, required=False, type=int)
-@click.option('--raw', is_flag=True)
-def calibration(id, raw):
+@click.argument('input_internal_id', nargs=1, required=True, type=str)
+def view(input_internal_id):
     print()
-    list_of_calibrations = client.get_calibration_data(id, None)
-    if id:
+    view_dict = client.get_view_links([input_internal_id])
+    body = [[input_internal_id, view_dict[input_internal_id]]]
+    headers = ["internal_id", "view_link"]
+    tab = _tabulate(body, headers, title="VIEW LINK")
+    print(tab)
+
+@click.command()
+@click.option('--id', nargs=1, default=None, required=False, type=int)
+@click.option("--external-id", nargs=1, required=False, type=str)
+@click.option('--raw', is_flag=True)
+def calibration(id, external_id, raw):
+    print()
+    if id is not None:
+        list_of_calibrations = client.get_calibration_data(id=id)
         headers = ["id", "external_id", "created"]
         tab = _get_table(list_of_calibrations, headers, "CALIBRATION")
         print(tab)
         if raw:
             print()
-            [print(calib.calibration) for calib in list_of_calibrations]
+            [pprint(calib.calibration) for calib in list_of_calibrations]
+    elif external_id is not None:
+        list_of_calibrations = client.get_calibration_data(external_id=external_id)
+        headers = ["id", "external_id", "created"]
+        tab = _get_table(list_of_calibrations, headers, "CALIBRATION")
+        print(tab)
     else:
+        list_of_calibrations = client.get_calibration_data()
         headers = ["id", "external_id", "created"]
         tab = _get_table(list_of_calibrations, headers, "CALIBRATION")
         print(tab)
 
 
-@click.command(name="calibration-externalid")
-@click.argument("external_id", nargs=1, required=True)
-def calibration_externalid(external_id):
-    print()
-    list_of_calibrations = client.get_calibration_data(None, external_id)
-    headers = ["id", "external_id", "created"]
-    tab = _get_table(list_of_calibrations, headers, "CALIBRATION")
-    print(tab)
-
-
-@click.argument('request_ids', nargs=-1)
-@click.command()
-def requests(request_ids):
-    headers = ["id", "created", "project_id", "title", "description",
-               "input_list_id", "input_batch_id", "external_id"]
-    request_ids_list = [int(rid) for rid in request_ids]
-    dict_of_requests = client.get_requests_for_request_ids(
-        request_ids=request_ids_list
-    )
-    list_of_requests = [dict_of_requests[k] for k in request_ids_list]
-    tab = _get_table(list_of_requests, headers, "REQUESTS")
-    print(tab)
-
-
-@click.command(name="input-lists")
-@click.argument('input_list_id', nargs=1, type=int, default=None, required=False)
-@click.option('--get-requests', is_flag=True)
-def input_lists(input_list_id, get_requests):
-    print()
-    if input_list_id and get_requests:
-        headers = ["id", "created", "project_id", "title", "description", "input_list_id"]
-        list_of_requests = client.get_requests_for_input_lists(input_list_id)
-        tab = _get_table(list_of_requests, headers, "REQUESTS")
-        print(tab)
-
-
-@click.command(name="batches")
-@click.argument('project', nargs=1, type=str, default=None, required=False)
-def input_batch(project):
-    print()
-    if project:
-        headers = ["external_id", "title",  "status", "created", "updated"]
-        list_of_batches = client.list_project_batches(project)
-        tab = _get_table(list_of_batches, headers, "BATCHES")
-        print(tab)
-
-
 cli.add_command(projects)
 cli.add_command(inputs)
-cli.add_command(inputs_externalid)
 cli.add_command(calibration)
-cli.add_command(calibration_externalid)
-cli.add_command(requests)
-cli.add_command(input_lists)
-cli.add_command(input_batch)
+cli.add_command(view)
 
 
 def main():

--- a/annotell-input-api/annotell/input_api/input_api_client.py
+++ b/annotell-input-api/annotell/input_api/input_api_client.py
@@ -9,7 +9,9 @@ from uuid import uuid4 as uuid
 import requests
 import time
 from PIL import Image
-from annotell.auth.authsession import FaultTolerantAuthRequestSession, DEFAULT_HOST as DEFAULT_AUTH_HOST
+from annotell.auth.authsession import (
+    FaultTolerantAuthRequestSession, DEFAULT_HOST as DEFAULT_AUTH_HOST
+)
 
 from . import input_api_model as IAM
 
@@ -17,24 +19,27 @@ DEFAULT_HOST = "https://input.annotell.com"
 
 log = logging.getLogger(__name__)
 
-RETRYABLE_STATUS_CODES = [408, 429, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 598, 599]
+RETRYABLE_STATUS_CODES = [408, 429, 500, 501, 502, 503,
+                          504, 505, 506, 507, 508, 509, 510, 511, 598, 599]
 
 
 class InputApiClient:
     """Creates Annotell inputs from local files."""
 
     def __init__(self, *,
-                 auth = None,
+                 auth=None,
                  host: str = DEFAULT_HOST,
                  auth_host: str = DEFAULT_AUTH_HOST,
                  client_organization_id: int = None,
                  max_upload_retry_attempts: int = 23,
                  max_upload_retry_wait_time: int = 60):
         """
-        :param auth: auth credentials, see https://github.com/annotell/annotell-python/tree/master/annotell-auth
+        :param auth: auth credentials, see
+        https://github.com/annotell/annotell-python/tree/master/annotell-auth
         :param host: override for input api url
         :param auth_host: override for authentication url
-        :param client_organization_id: Overrides your users organization id. Only works with an Annotell user.
+        :param client_organization_id: Overrides your users organization id.
+        Only works with an Annotell user.
         :param max_upload_retry_attempts: Max number of attempts to retry uploading a file to GCS.
         :param max_upload_retry_wait_time:  Max with time before retrying an upload to GCS.
         """
@@ -51,7 +56,8 @@ class InputApiClient:
         self.MAX_RETRY_WAIT_TIME = max_upload_retry_wait_time  # seconds
         if client_organization_id is not None:
             self.headers["X-Organization-Id"] = str(client_organization_id)
-            log.info(f"WARNING: You will now act as if you are part of organization: {client_organization_id}. "
+            c_org_id = client_organization_id
+            log.info(f"WARNING: You will now act as if you are part of organization: {c_org_id}. "
                      f"This will not work unless you are an Annotell user.")
 
     @property
@@ -70,7 +76,7 @@ class InputApiClient:
                 except ValueError:
                     message = exception.response.text
                 raise RuntimeError(message) from exception
-            
+
             raise exception from None
         return resp
 
@@ -106,8 +112,8 @@ class InputApiClient:
         if filename.split(".")[-1] == "csv":
             content_type = "text/csv"
         else:
-            content_type = mimetypes.guess_type(filename)[0]
-            content_type = content_type if content_type is not None else 'application/octet-stream'
+            ct = mimetypes.guess_type(filename)[0]
+            content_type = ct if ct is not None else 'application/octet-stream'
 
         return content_type
 
@@ -125,7 +131,9 @@ class InputApiClient:
 
     #  Using similar retry strategy as gsutil
     #  https://cloud.google.com/storage/docs/gsutil/addlhelp/RetryHandlingStrategy
-    def _upload_file(self, upload_url: str, file: BinaryIO, headers: Dict[str, str], upload_attempt: int = 1) -> None:
+    def _upload_file(
+            self, upload_url: str, file: BinaryIO, headers: Dict[str, str],
+            upload_attempt: int = 1) -> None:
         """
         Upload the file to GCS, retries if the upload fails with some specific status codes.
         """
@@ -137,7 +145,10 @@ class InputApiClient:
             log.error(f"On upload attempt ({upload_attempt}/{self.MAX_NUM_UPLOAD_RETRIES}) to GCS "
                       f"got response:\n{resp.status_code}: {resp.content}")
 
-            if upload_attempt < self.MAX_NUM_UPLOAD_RETRIES and resp.status_code in RETRYABLE_STATUS_CODES:
+            attempt_cond = upload_attempt < self.MAX_NUM_UPLOAD_RETRIES
+            status_code_cond = resp.status_code in RETRYABLE_STATUS_CODES
+
+            if attempt_cond and status_code_cond:
                 wait_time = self._get_wait_time(upload_attempt)
                 log.info(f"Waiting {int(wait_time)} seconds before retrying")
                 time.sleep(wait_time)
@@ -195,46 +206,14 @@ class InputApiClient:
         if not dryrun:
             return IAM.CreateInputJobResponse.from_json(json_resp)
 
-    def get_inputs(self, project_id: int, invalidated: bool = False) -> List[IAM.Input]:
-        """
-        Gets inputs for project, with option to filter for invalidated inputs
-
-        :param project_id: Project id to filter
-        :param invalidated: Returns invalidated inputs if True, otherwise valid inputs
-        :return List: List of Inputs
-        """
-
-        url = f"{self.host}/v1/inputs?projectId={project_id}&invalidated={invalidated}"
-        resp = self.session.get(url, headers=self.headers)
-        json_resp = self._unwrap_enveloped_json(self._raise_on_error(resp).json())
-        return [IAM.Input.from_json(js) for js in json_resp]
-
-
-    def count_inputs_for_external_ids(self, external_ids: List[str]) -> Dict[str, int]:
-        """
-        For each external id, returns a count of how many inputs exists with that external id.
-
-        :param external_ids: List of external ids
-        :return Dict: Dictionary which maps an external id to a count of inputs with that external id
-        """
-
-        if len(external_ids) == 0:
-            log.error("You need to specify a list of external ids.")
-            return
-
-        external_ids_csv = ",".join(external_ids)
-        url = f"{self.host}/v1/inputs/count-for-ids?externalIds={external_ids_csv}"
-        resp = self.session.get(url, headers=self.headers)
-        json_resp = self._unwrap_enveloped_json(self._raise_on_error(resp).json())
-        return json_resp
-
-    def _create_inputs_point_cloud_with_images(self, point_clouds_with_images: IAM.PointCloudsWithImages,
-                                               internal_id: str,
-                                               metadata: IAM.CalibratedSceneMetaData,
-                                               project: Optional[str],
-                                               batch: Optional[str],
-                                               input_list_id: Optional[int],
-                                               dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
+    def _create_inputs_point_cloud_with_images(
+            self, point_clouds_with_images: IAM.PointCloudsWithImages,
+            internal_id: str,
+            metadata: IAM.CalibratedSceneMetaData,
+            project: Optional[str],
+            batch: Optional[str],
+            input_list_id: Optional[int],
+            dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
         """Create point cloud with images"""
 
         js = dict(
@@ -242,74 +221,23 @@ class InputApiClient:
             internalId=internal_id,
             metadata=metadata.to_dict())
 
-        return self._post_input_request('pointclouds-with-images', js, project=project, batch=batch, input_list_id=input_list_id, dryrun=dryrun)
+        resp = self._post_input_request(
+            'pointclouds-with-images',
+            js,
+            project=project,
+            batch=batch,
+            input_list_id=input_list_id,
+            dryrun=dryrun
+        )
+        return resp
 
-    def create_inputs_point_cloud_with_images(self, folder: Path,
-                                              point_clouds_with_images: IAM.PointCloudsWithImages,
-                                              metadata: IAM.CalibratedSceneMetaData,
-                                              project: Optional[str] = None,
-                                              batch: Optional[str] = None,
-                                              input_list_id: Optional[int] = None,
-                                              dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
-        """
-        Upload files and create an input of type 'point_cloud_with_image'.
-
-        :param folder: path to folder containing files
-        :param point_clouds_with_images: class containing images and pointclouds that constitute the input
-        :param metadata: Class containing metadata necessary for point cloud with images
-        :param project: project to add input to
-        :param batch: batch, defaults to latest open batch
-        :param input_list_id: input list to add input to (alternative to project-batch)
-        :param dryrun: If True the files/metadata will be validated but no input job will be created.
-        :returns CreateInputJobResponse: Class containing id of the created input job, or None if dryrun.
-
-        The files are uploaded to annotell GCS and an input_job is submitted to the inputEngine.
-        In order to increase annotation tool performance the supplied pointcloud-file is converted
-        into potree after upload (server side). Supported fileformats for pointcloud files are
-        currently .csv & .pcd (more information about formatting can be found in the readme.md).
-        The job is successful once it converts the pointcloud file into potree, at which time an
-        input of type 'point_cloud_with_image' is created for the designated `project` `batch` or `input_list_id`.
-        If the input_job fails (cannot perform conversion) the input is not added. To see if
-        conversion was successful please see the method `get_input_jobs_status`.
-        """
-
-        files_on_disk = [image.filename for image in point_clouds_with_images.images] + \
-                        [pc.filename for pc in point_clouds_with_images.point_clouds]
-
-        upload_urls_response = self._get_upload_urls(IAM.FilesToUpload(files_on_disk))
-
-        files_in_response = list(upload_urls_response.files_to_url.keys())
-        assert set(files_on_disk) == set(files_in_response)
-
-        self._set_images_dimensions(folder, point_clouds_with_images.images)
-        self._create_inputs_point_cloud_with_images(point_clouds_with_images,
-                                                    upload_urls_response.internal_id,
-                                                    metadata,
-                                                    project=project,
-                                                    batch=batch,
-                                                    input_list_id=input_list_id,
-                                                    dryrun=True)
-        if not dryrun:
-            self._upload_files(folder, upload_urls_response.files_to_url)
-
-            create_input_response = self._create_inputs_point_cloud_with_images(point_clouds_with_images,
-                                                                                upload_urls_response.internal_id,
-                                                                                metadata,
-                                                                                project=project,
-                                                                                batch=batch,
-                                                                                input_list_id=input_list_id,
-                                                                                )
-
-            log.info(f"Creating inputs for files with job_id={create_input_response.internal_id}")
-            return create_input_response
-    
     def _create_inputs_point_clouds(self, point_clouds: IAM.PointCloudFiles,
-                                               internal_id: str,
-                                               metadata: IAM.SceneMetaData,
-                                               project: Optional[str],
-                                               batch: Optional[str],
-                                               input_list_id: Optional[int],
-                                               dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
+                                    internal_id: str,
+                                    metadata: IAM.SceneMetaData,
+                                    project: Optional[str],
+                                    batch: Optional[str],
+                                    input_list_id: Optional[int],
+                                    dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
         """Create point clouds"""
 
         js = dict(
@@ -317,95 +245,53 @@ class InputApiClient:
             internalId=internal_id,
             metadata=metadata.to_dict())
 
-        return self._post_input_request('pointclouds', js, project=project, batch=batch, input_list_id=input_list_id, dryrun=dryrun)
+        resp = self._post_input_request(
+            'pointclouds',
+            js,
+            project=project,
+            batch=batch,
+            input_list_id=input_list_id,
+            dryrun=dryrun
+        )
+        return resp
 
-    def create_inputs_point_clouds(self, folder: Path,
-                                   point_clouds: IAM.PointCloudFiles,
-                                   metadata: IAM.SceneMetaData = IAM.SceneMetaData(external_id=str(uuid())),
-                                   project: Optional[str] = None,
-                                   batch: Optional[str] = None,
-                                   input_list_id: Optional[int] = None,
-                                   dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
+    def _create_images_input_job(self, images_files: IAM.ImagesFiles,
+                                 metadata: IAM.SceneMetaData,
+                                 internal_id: str,
+                                 project: Optional[str],
+                                 batch: Optional[str],
+                                 input_list_id: Optional[int],
+                                 dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
         """
-        Upload files and create an input of type 'point_cloud'.
+        Creates an input job for an image input
 
-        :param folder: path to folder containing files
-        :param point_clouds: list of pointclouds that constitute the input
-        :param metadata: Class containing metadata necessary for point cloud
-        :param project: project to add input to
-        :param batch: batch, defaults to latest open batch
-        :param input_list_id: input list to add input to (alternative to project-batch)
-        :param dryrun: If True the files/metadata will be validated but no input job will be created.
-        :returns CreateInputJobResponse: Class containing id of the created input job, or None if dryrun.
-
-        The files are uploaded to annotell GCS and an input_job is submitted to the inputEngine.
-        In order to increase annotation tool performance the supplied pointcloud-file is converted
-        into potree after upload (server side). Supported fileformats for pointcloud files are
-        currently .csv & .pcd (more information about formatting can be found in the readme.md).
-        The job is successful once it converts the pointcloud file into potree, at which time an
-        input of type 'point_cloud' is created for the designated `project` `batch` or `input_list_id`.
-        If the input_job fails (cannot perform conversion) the input is not added. To see if
-        conversion was successful please see the method `get_input_jobs_status`.
-        """
-
-        files_on_disk = [pc.filename for pc in point_clouds.point_clouds]
-
-        upload_urls_response = self._get_upload_urls(IAM.FilesToUpload(files_on_disk))
-
-        files_in_response = list(upload_urls_response.files_to_url.keys())
-        assert set(files_on_disk) == set(files_in_response)
-
-        self._create_inputs_point_clouds(point_clouds,
-                                         upload_urls_response.internal_id,
-                                         metadata,
-                                         project=project,
-                                         batch=batch,
-                                         input_list_id=input_list_id,
-                                         dryrun=True)
-        if not dryrun:
-            # self._upload_files(folder, upload_urls_response.files_to_url)
-
-            create_input_response = self._create_inputs_point_clouds(point_clouds,
-                                                                     upload_urls_response.internal_id,
-                                                                     metadata,
-                                                                     project=project,
-                                                                     batch=batch,
-                                                                     input_list_id=input_list_id,
-                                                                     )
-
-            log.info(f"Creating inputs for files with job_id={create_input_response.internal_id}")
-            return create_input_response
-
-    def create_slam_input_job(self, slam_files: IAM.SlamFiles,
-                              metadata: IAM.SlamMetaData,
-                              project: Optional[str] = None,
-                              batch: Optional[str] = None,
-                              input_list_id: Optional[int] = None,
-                              dryrun=False) -> Optional[IAM.CreateInputJobResponse]:
-        """
-        Creates a slam input job, then sends a message to inputEngine which will request for a SLAM job to be
-        started.
-
-        :param slam_files: class containing files necessary for SLAM.
-        :param metadata: class containing metadata necessary for SLAM.
-        :param project: project to add input to
-        :param batch: batch, defaults to latest open batch
-        :param input_list_id: input list to add input to (alternative to project-batch)
-        :param dryrun: If True the files/metadata will be validated but no input job will be created.
-        :returns CreateInputJobResponse: Class containing id of the created input job, or None if dryrun.
+        :param images_files: Contains all images, with their dimensions
+        :param metadata: Contains necessary metadata in order to create and validate inputs
+        :param input_list_id: input list id which the new input will be added to
+        :param internal_id: When created, the input will use this internal id.
+        :param dryrun: If True the files/metadata will be validated but no input job will
+        be created.
+        :returns CreateInputJobResponse: Class containing id of the created input job, or None
+        if dryrun
         """
 
-        slam_json = dict(files=slam_files.to_dict(), metadata=metadata.to_dict(), inputListId=input_list_id)
+        create_input_job_json = dict(files=images_files.to_dict(),
+                                     metadata=metadata.to_dict(),
+                                     internalId=internal_id)
+        resp = self._post_input_request(
+            'images', create_input_job_json, project=project, batch=batch,
+            input_list_id=input_list_id, dryrun=dryrun
+        )
+        return resp
 
-        return self._post_input_request('slam', slam_json, project=project, batch=batch, input_list_id=input_list_id, dryrun=dryrun)
-
-    def upload_and_create_images_input_job(self, folder: Path,
-                                           images_files: IAM.ImagesFiles,
-                                           metadata: IAM.SceneMetaData = IAM.SceneMetaData(external_id=str(uuid())),
-                                           project: Optional[str] = None,
-                                           batch: Optional[str] = None,
-                                           input_list_id: Optional[int] = None,
-                                           dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
+    def create_inputs_images(
+            self, folder: Path,
+            images_files: IAM.ImagesFiles,
+            metadata: IAM.SceneMetaData = IAM.SceneMetaData(external_id=str(uuid())),
+            project: Optional[str] = None,
+            batch: Optional[str] = None,
+            input_list_id: Optional[int] = None,
+            dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
         """
         Verifies the images and metadata given and then uploads images to Google Cloud Storage and
         creates an input job.
@@ -415,8 +301,10 @@ class InputApiClient:
         :param project: project to add input to
         :param batch: batch, defaults to latest open batch
         :param input_list_id: input list to add input to (alternative to project-batch)
-        :param dryrun: If True the files/metadata will be validated but no input job will be created.
-        :returns InputJobCreatedMessage: Class containing id of the created input job, or None if dryrun.
+        :param dryrun: If True the files/metadata will be validated but no input job
+        will be created.
+        :returns InputJobCreatedMessage: Class containing id of the created input job,
+        or None if dryrun.
         """
 
         self._set_images_dimensions(folder, images_files.images)
@@ -445,41 +333,189 @@ class InputApiClient:
                                                                       batch=batch,
                                                                       input_list_id=input_list_id
                                                                       )
-            log.info(f"Creating input for images with internal_id={input_job_created_message.internal_id}")
+            if input_job_created_message:
+                int_id = input_job_created_message.internal_id
+                log.info(
+                    f"Creating input for images with internal_id={int_id}")
             return input_job_created_message
+        return None
 
-    def _create_images_input_job(self, images_files: IAM.ImagesFiles,
-                                 metadata: IAM.SceneMetaData,
-                                 internal_id: str,
-                                 project: Optional[str],
-                                 batch: Optional[str],
-                                 input_list_id: Optional[int],
-                                 dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
+    def create_inputs_point_clouds(
+            self, folder: Path,
+            point_clouds: IAM.PointCloudFiles,
+            metadata: IAM.SceneMetaData = IAM.SceneMetaData(external_id=str(uuid())),
+            project: Optional[str] = None,
+            batch: Optional[str] = None,
+            input_list_id: Optional[int] = None,
+            dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
         """
-        Creates an input job for an image input
+        Upload files and create an input of type 'point_cloud'.
 
-        :param images_files: Contains all images, with their dimensions
-        :param metadata: Contains necessary metadata in order to create and validate inputs
-        :param input_list_id: input list id which the new input will be added to
-        :param internal_id: When created, the input will use this internal id.
-        :param dryrun: If True the files/metadata will be validated but no input job will be created.
-        :returns CreateInputJobResponse: Class containing id of the created input job, or None if dryrun
+        :param folder: path to folder containing files
+        :param point_clouds: list of pointclouds that constitute the input
+        :param metadata: Class containing metadata necessary for point cloud
+        :param project: project to add input to
+        :param batch: batch, defaults to latest open batch
+        :param input_list_id: input list to add input to (alternative to project-batch)
+        :param dryrun: If True the files/metadata will be validated but no input job will
+        be created.
+        :returns CreateInputJobResponse: Class containing id of the created input job,
+        or None if dryrun.
+
+        The files are uploaded to annotell GCS and an input_job is submitted to the inputEngine.
+        In order to increase annotation tool performance the supplied pointcloud-file is converted
+        into potree after upload (server side). Supported fileformats for pointcloud files are
+        currently .csv & .pcd (more information about formatting can be found in the readme.md).
+        The job is successful once it converts the pointcloud file into potree, at which time an
+        input of type 'point_cloud' is created for the designated `project` `batch` or
+        `input_list_id`. If the input_job fails (cannot perform conversion) the input is not added.
+        To see if conversion was successful please see the method `get_input_jobs_status`.
         """
 
-        create_input_job_json = dict(files=images_files.to_dict(),
-                                     metadata=metadata.to_dict(),
-                                     internalId=internal_id)
+        files_on_disk = [pc.filename for pc in point_clouds.point_clouds]
 
-        return self._post_input_request('images', create_input_job_json, project=project, batch=batch, input_list_id=input_list_id, dryrun=dryrun)
+        upload_urls_response = self._get_upload_urls(IAM.FilesToUpload(files_on_disk))
+
+        files_in_response = list(upload_urls_response.files_to_url.keys())
+        assert set(files_on_disk) == set(files_in_response)
+
+        self._create_inputs_point_clouds(point_clouds,
+                                         upload_urls_response.internal_id,
+                                         metadata,
+                                         project=project,
+                                         batch=batch,
+                                         input_list_id=input_list_id,
+                                         dryrun=True)
+        if not dryrun:
+            # self._upload_files(folder, upload_urls_response.files_to_url)
+
+            create_input_response = self._create_inputs_point_clouds(
+                point_clouds,
+                upload_urls_response.internal_id,
+                metadata,
+                project=project,
+                batch=batch,
+                input_list_id=input_list_id,
+            )
+            if create_input_response:
+                log.info(
+                    f"Creating inputs for files with job_id={create_input_response.internal_id}"
+                )
+            return create_input_response
+        return None
+
+    def create_inputs_point_cloud_with_images(
+            self, folder: Path,
+            point_clouds_with_images: IAM.PointCloudsWithImages,
+            metadata: IAM.CalibratedSceneMetaData,
+            project: Optional[str] = None,
+            batch: Optional[str] = None,
+            input_list_id: Optional[int] = None,
+            dryrun: bool = False) -> Optional[IAM.CreateInputJobResponse]:
+        """
+        Upload files and create an input of type 'point_cloud_with_image'.
+
+        :param folder: path to folder containing files
+        :param point_clouds_with_images: class containing images and pointclouds that
+        constitute the input
+        :param metadata: Class containing metadata necessary for point cloud with images
+        :param project: project to add input to
+        :param batch: batch, defaults to latest open batch
+        :param input_list_id: input list to add input to (alternative to project-batch)
+        :param dryrun: If True the files/metadata will be validated but no input job will be
+        created.
+        :returns CreateInputJobResponse: Class containing id of the created input job,
+        or None if dryrun.
+
+        The files are uploaded to annotell GCS and an input_job is submitted to the inputEngine.
+        In order to increase annotation tool performance the supplied pointcloud-file is converted
+        into potree after upload (server side). Supported fileformats for pointcloud files are
+        currently .csv & .pcd (more information about formatting can be found in the readme.md).
+        The job is successful once it converts the pointcloud file into potree, at which time an
+        input of type 'point_cloud_with_image' is created for the designated `project` `batch` or
+        `input_list_id`. If the input_job fails (cannot perform conversion) the input is not added.
+        To see if conversion was successful please see the method `get_input_jobs_status`.
+        """
+
+        files_on_disk = [image.filename for image in point_clouds_with_images.images] + \
+                        [pc.filename for pc in point_clouds_with_images.point_clouds]
+
+        upload_urls_response = self._get_upload_urls(IAM.FilesToUpload(files_on_disk))
+
+        files_in_response = list(upload_urls_response.files_to_url.keys())
+        assert set(files_on_disk) == set(files_in_response)
+
+        self._set_images_dimensions(folder, point_clouds_with_images.images)
+        self._create_inputs_point_cloud_with_images(point_clouds_with_images,
+                                                    upload_urls_response.internal_id,
+                                                    metadata,
+                                                    project=project,
+                                                    batch=batch,
+                                                    input_list_id=input_list_id,
+                                                    dryrun=True)
+        if not dryrun:
+            self._upload_files(folder, upload_urls_response.files_to_url)
+
+            create_input_response = self._create_inputs_point_cloud_with_images(
+                point_clouds_with_images,
+                upload_urls_response.internal_id,
+                metadata,
+                project=project,
+                batch=batch,
+                input_list_id=input_list_id,
+            )
+
+            if create_input_response:
+                log.info(
+                    f"Creating inputs for files with job_id={create_input_response.internal_id}"
+                )
+            return create_input_response
+        return None
+
+    def create_slam_input_job(self, slam_files: IAM.SlamFiles,
+                              metadata: IAM.SlamMetaData,
+                              project: Optional[str] = None,
+                              batch: Optional[str] = None,
+                              input_list_id: Optional[int] = None,
+                              dryrun=False) -> Optional[IAM.CreateInputJobResponse]:
+        """
+        Creates a slam input job, then sends a message to inputEngine which will request for a
+        SLAM job to be started.
+
+        :param slam_files: class containing files necessary for SLAM.
+        :param metadata: class containing metadata necessary for SLAM.
+        :param project: project to add input to
+        :param batch: batch, defaults to latest open batch
+        :param input_list_id: input list to add input to (alternative to project-batch)
+        :param dryrun: If True the files/metadata will be validated but
+        no input job will be created.
+        :returns CreateInputJobResponse: Class containing id of the created input job,
+        or None if dryrun.
+        """
+
+        slam_json = dict(files=slam_files.to_dict(),
+                         metadata=metadata.to_dict(), inputListId=input_list_id)
+
+        resp = self._post_input_request(
+            'slam',
+            slam_json,
+            project=project,
+            batch=batch,
+            input_list_id=input_list_id,
+            dryrun=dryrun
+        )
+        return resp
 
     def update_completed_slam_input_job(self, pointcloud_uri: str,
                                         trajectory: IAM.Trajectory,
                                         job_id: str) -> None:
         """
-        Updates an input job with data about the created SLAM, then sends a message to inputEngine which
-        will create an input. The method will throw an error if the operation was unsuccessful.
+        Updates an input job with data about the created SLAM, then sends a message to inputEngine
+        which will create an input. The method will throw an error if the operation was
+        unsuccessful.
 
-        :param pointcloud_uri: URI pointing to a SLAM:ed pointcloud in either s3 or gs cloud storage.
+        :param pointcloud_uri: URI pointing to a SLAM:ed pointcloud in either s3 or gs cloud
+        storage.
         :param trajectory: class containing the trajectory of the SLAM:ed pointcloud.
         :param job_id: UUID for the input job.
         :returns None
@@ -506,6 +542,28 @@ class InputApiClient:
         resp = self.session.post(url, json=update_json, headers=self.headers)
         self._raise_on_error(resp).json()
 
+    def get_inputs(self,
+                   project: str, batch: Optional[str] = None,
+                   include_invalidated: bool = False) -> List[IAM.Input]:
+        """
+        Gets inputs for project, with option to include invalidated inputs in the list
+        (by default invalidated inputs are omitted)
+
+        :param project: Project to filter
+        :param batch: Batch to filter, if omitted inputs from all batches are included.
+        :param invalidated: If true, includes invalidated inputs in the response
+        :return List: List of Inputs
+        """
+
+        url = f"{self.host}/v1/inputs"
+        resp = self.session.get(url, params={
+            "project": project,
+            "batch": batch,
+            "invalidated": include_invalidated
+        }, headers=self.headers)
+        json_resp = self._unwrap_enveloped_json(self._raise_on_error(resp).json())
+        return [IAM.Input.from_json(js) for js in json_resp]
+
     def get_internal_ids_for_external_ids(self, external_ids: List[str]) -> Dict[str, List[str]]:
         """
         For each external id returns a list of internal ids, connected to the external id.
@@ -518,41 +576,23 @@ class InputApiClient:
         resp = self.session.get(url, json=js, headers=self.headers)
         return self._raise_on_error(resp).json()
 
-    def mend_input_data(self):
-        """Not yet implemented."""
-        url = f"{self.host}/v1/inputs/mend-input-metadata"
-        resp = self.session.get(url, headers=self.headers)
-        return self._raise_on_error(resp).json()
-
-    def invalidate_inputs(self, input_ids: List[str], invalidated_reason: IAM.InvalidatedReasonInput):
+    def invalidate_inputs(
+            self, input_internal_ids: List[str], invalidated_reason: IAM.InvalidatedReasonInput
+    ) -> IAM.InvalidatedInputsResponse:
         """
         Invalidates inputs, and removes them from all input lists
 
-        :param input_ids: The input internal ids to invalidate
+        :param input_internal_ids: The input internal ids to invalidate
         :param invalidated_reason: An Enum describing why inputs were invalidated
         :return InvalidatedInputsResponse: Class containing what inputs were invalidated
         """
         url = f"{self.host}/v1/inputs/invalidate"
-        invalidated_json = dict(inputIds=input_ids, invalidatedReason=invalidated_reason)
+        invalidated_json = dict(inputIds=input_internal_ids, invalidatedReason=invalidated_reason)
         resp = self.session.post(url, json=invalidated_json, headers=self.headers)
         resp_json = self._unwrap_enveloped_json(self._raise_on_error(resp).json())
         return IAM.InvalidatedInputsResponse.from_json(resp_json)
 
-    def remove_inputs_from_input_list(self, input_list_id: int, input_ids: List[int]):
-        """
-        Removes inputs from specified input list, without invalidating the input
-
-        :param input_list_id: The input list id where the inputs should be removed
-        :param input_ids: The input ids to remove
-        :return RemovedInputsResponse: Class containing what inputs were removed
-        """
-        url = f"{self.host}/v1/inputs/remove"
-        removed_json = dict(inputListId=input_list_id, inputIds=input_ids)
-        resp = self.session.post(url, json=removed_json, headers=self.headers)
-        resp_json = self._unwrap_enveloped_json(self._raise_on_error(resp).json())
-        return IAM.RemovedInputsResponse.from_json(resp_json)
-
-    def list_projects(self) -> List[IAM.Project]:
+    def get_projects(self) -> List[IAM.Project]:
         """
         Returns all projects connected to the users organization.
 
@@ -563,10 +603,11 @@ class InputApiClient:
         json_resp = self._raise_on_error(resp).json()
         return [IAM.Project.from_json(js) for js in json_resp]
 
-    def list_project_batches(self, project: str) -> List[IAM.Project]:
+    def get_project_batches(self, project: str) -> List[IAM.InputBatch]:
         """
         Returns all `batches` for the `project`.
 
+        :param project: Project identifier
         :return List: List containing all batches
         """
         url = f"{self.host}/v1/inputs/project/{project}/batch"
@@ -574,32 +615,9 @@ class InputApiClient:
         json_resp = self._raise_on_error(resp).json()
         return [IAM.InputBatch.from_json(js) for js in json_resp]
 
-    def list_input_lists(self, project_id: int) -> List[IAM.InputList]:
-        """
-        Returns a list of all input lists connected to the specified project.
-
-        :param project_id: The id of the project
-        :return List: List with the input lists connected to the project id
-        """
-        url = f"{self.host}/v1/inputs/input-lists?projectId={project_id}"
-        resp = self.session.get(url, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-        return [IAM.InputList.from_json(js) for js in json_resp]
-
-    def publish_batch(self, project: str, batch: str) -> IAM.InputBatch:
-        """
-        Publish input batch, marking the input batch ready for annotation.
-        After publishing, no more inputs can be added to the input batch
-
-        :return InputBatch: Updated input batch
-        """
-        url = f"{self.host}/v1/inputs/project/{project}/batch/{batch}/publish"
-        resp = self.session.post(url, headers=self.headers)
-        json_resp = self._unwrap_enveloped_json(self._raise_on_error(resp).json())
-        return IAM.InputBatch.from_json(json_resp)
-
-    def get_calibration_data(self, id: Optional[int] = None, external_id: Optional[str] = None
-                             ) -> Union[List[IAM.CalibrationNoContent], List[IAM.CalibrationWithContent]]:
+    def get_calibration_data(
+        self, id: Optional[int] = None, external_id: Optional[str] = None
+    ) -> Union[List[IAM.CalibrationNoContent], List[IAM.CalibrationWithContent]]:
         """
         Queries the Input API for either:
         * A list containing a specific calibration (of only the id is given)
@@ -609,8 +627,8 @@ class InputApiClient:
 
         :param id: The id of the calibration to get
         :param external_id: The external id of the calibration(s) to get
-        :return List: A list of CalibrationNoContent if an id or external id was given, or a list of
-        CalibrationWithContent otherwise.
+        :return List: A list of CalibrationNoContent if an id or external id was given, or a
+        list of CalibrationWithContent otherwise.
         """
         base_url = f"{self.host}/v1/inputs/calibration-data"
         if id:
@@ -628,100 +646,42 @@ class InputApiClient:
         else:
             return [IAM.CalibrationWithContent.from_json(js) for js in json_resp]
 
-    def create_calibration_data(self, calibration_spec: IAM.CalibrationSpec) -> IAM.CalibrationNoContent:
+    def create_calibration_data(
+        self, calibration_spec: IAM.CalibrationSpec
+    ) -> IAM.CalibrationNoContent:
         """
         Creates a new calibration, given the CalibrationSpec
-        :param calibration_spec: A CalibrationSpec instance containing everything to create a calibration.
-        :return CalibrationNoContent: Class containing the calibration id, external id and time of creation.
+        :param calibration_spec: A CalibrationSpec instance containing everything to
+        create a calibration.
+        :return CalibrationNoContent: Class containing the calibration id, external id and
+        time of creation.
         """
         url = f"{self.host}/v1/inputs/calibration-data"
         resp = self.session.post(url, json=calibration_spec.to_dict(), headers=self.headers)
         json_resp = self._raise_on_error(resp).json()
         return IAM.CalibrationNoContent.from_json(json_resp)
 
-    def get_requests_for_request_ids(self, request_ids: List[int]) -> Dict[int, IAM.Request]:
+    def download_annotations(
+        self, internal_ids: List[str]
+    ) -> Dict[str, List[IAM.ExportAnnotation]]:
         """
-        Returns a list of request objects, given a list of request ids
-
-        :param request_ids: List of request ids
-        :return Dict: Dictionary mapping a request id to a Request object
-        """
-        url = f"{self.host}/v1/inputs/requests"
-        js = request_ids
-        resp = self.session.get(url, json=js, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-        dict_resp = dict()
-        for k, v in json_resp.items():
-            dict_resp[int(k)] = IAM.Request.from_json(v)
-        return dict_resp
-
-    def get_requests_for_input_lists(self, input_list_id: int) -> List[IAM.Request]:
-        """
-        Returns all requests connected to a specific input list
-
-        :param input_list_id: The input list id we want to get the connected Requests for.
-        :return List: List of Request objects
-        """
-        url = f"{self.host}/v1/inputs/requests?inputListId={input_list_id}"
-        resp = self.session.get(url, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-        return [IAM.Request.from_json(js) for js in json_resp]
-
-    def get_input_status(self, internal_ids: List[str]) -> Dict[str, Dict[int, bool]]:
-        """
-        Returns a nested dictionary, the outmost key is the internal_id, which points to a
-        dictionary whose keys are the request_ids for the requests where the input is included
-        (via the inputList). The key is a boolean denoting if the input is ready for export (true)
-        or not (false).
-
-        :param internal_ids: List of internal ids
-        :return Dict: Nested dictionary that for each input and request specify it is ready
-        for export or not.
-        """
-        url = f"{self.host}/v1/inputs/export-status"
-        js = internal_ids
-        resp = self.session.get(url, json=js, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-        for k, v in json_resp.items():
-            inner_dict_resp = dict()
-            for kk, vv in v.items():
-                inner_dict_resp[int(kk)] = vv
-            json_resp[k] = inner_dict_resp
-
-        return json_resp
-
-    def download_annotations(self, internal_ids: List[str], request_id: Optional[int] = None
-                             ) -> Dict[str, Union[Dict[int, IAM.ExportAnnotation], IAM.ExportAnnotation]]:
-        """
-        Returns the export ready annotations, either
-        * All annotations connected to a specific request, if a request id is given
-        * All annotations connected to the organization of the user, if no request id is given
+        Returns the export ready annotations for each input (via the internal id).
 
         :param internal_ids: List with internal ids
-        :param request_id: An id of a request
-        :return Dict: A dictionary containing the ready annotations
+        :return Dict: A dictionary, with each key corresponding internal_id, and value
+        corresponding to a list of the ready annotations for the associated input.
         """
-        base_url = f"{self.host}/v1/inputs/export"
-        if request_id:
-            url = base_url + f"?requestId={request_id}"
-        else:
-            url = base_url
+        url = f"{self.host}/v1/inputs/export"
         js = internal_ids
         resp = self.session.get(url, json=js, headers=self.headers)
         json_resp = self._raise_on_error(resp).json()
 
-        if base_url == url:
-            for k, v in json_resp.items():
-                inner_dict_resp = dict()
-                for kk, vv in v.items():
-                    inner_dict_resp[int(kk)] = IAM.ExportAnnotation.from_json(vv)
-                json_resp[k] = inner_dict_resp
-            return json_resp
-
-        else:
-            for k, v in json_resp.items():
-                json_resp[k] = IAM.ExportAnnotation.from_json(v)
-            return json_resp
+        for k, v in json_resp.items():
+            inner_list = list()
+            for kk, vv in v.items():
+                inner_list.append(IAM.ExportAnnotation.from_json(vv))
+            json_resp[k] = inner_list
+        return json_resp
 
     def get_view_links(self, internal_ids: List[str]) -> Dict[str, str]:
         """
@@ -730,87 +690,8 @@ class InputApiClient:
         :param internal_ids: List with internal ids
         :return Dict: Dictionary mapping each internal id with an URL to view the input.
         """
-        base_url = f"{self.host}/v1/inputs/view-links"
-        js = internal_ids
-        resp = self.session.get(base_url, json=js, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-        return json_resp
+        view_dict = dict()
+        for internal_id in internal_ids:
+            view_dict[internal_id] = f"https://app.annotell.com/input-view/{internal_id}"
 
-    def get_input_jobs_status(self, internal_ids: Optional[List[str]] = None,
-                              external_ids: Optional[List[str]] = None
-                              ) -> List[IAM.InputJob]:
-        """
-        Returns a list of input jobs, either:
-        * All input jobs connected to the given lists of internal and external ids
-        * All input jobs connected to the user organization, if no ids were given
-
-        :param internal_ids: List of internal ids
-        :param external_ids: List of external ids
-        :return List: List containing InputJob objects
-        """
-        if internal_ids is None:
-            internal_ids = []
-        if external_ids is None:
-            external_ids = []
-
-        base_url = f"{self.host}/v1/inputs/job-status"
-        js = dict(
-            internalIds=internal_ids,
-            externalIds=external_ids
-        )
-        resp = self.session.post(base_url, json=js, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-
-        return [IAM.InputJob.from_json(js) for js in json_resp]
-
-    def get_requests_for_project_id(self, project_id: int) -> List[IAM.Request]:
-        """
-        Returns all Requests connected to a project id
-
-        :param project_id: A project id
-        :return List: List containing Request objects
-        """
-        base_url = f"{self.host}/v1/inputs/requests?projectId={project_id}"
-        resp = self.session.get(base_url, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-        return [IAM.Request.from_json(js) for js in json_resp]
-
-    def get_datas_for_inputs_by_internal_ids(self, internal_ids: List[str]) -> Mapping[IAM.Input, List[IAM.Data]]:
-        """
-        For every internal id given, returns that input together with all the data connected to that input
-
-        :param internal_ids: List of internal ids
-        :return Mapping: Maps a Input with all the data conntected to it
-        """
-        base_url = f"{self.host}/v1/inputs/datas-internal-id"
-        js = internal_ids
-        resp = self.session.get(base_url, json=js, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-
-        new_dict = {}
-        for (k, v) in json_resp:
-            new_key = IAM.Input.from_json(k)
-            new_values = [IAM.Data.from_json(vv) for vv in v]
-            new_dict[new_key] = new_values
-
-        return new_dict
-
-    def get_datas_for_inputs_by_external_ids(self, external_ids: List[str]) -> Mapping[IAM.Input, List[IAM.Data]]:
-        """
-        For every external id given, returns that input together with all the data connected to that input
-
-        :param external_ids: List of external ids
-        :return Mapping: Maps a Input with all the data connected to it
-        """
-        base_url = f"{self.host}/v1/inputs/datas-external-id"
-        js = external_ids
-        resp = self.session.get(base_url, json=js, headers=self.headers)
-        json_resp = self._raise_on_error(resp).json()
-
-        new_dict = {}
-        for (k, v) in json_resp:
-            new_key = IAM.Input.from_json(k)
-            new_values = [IAM.Data.from_json(vv) for vv in v]
-            new_dict[new_key] = new_values
-
-        return new_dict
+        return view_dict

--- a/annotell-input-api/annotell/input_api/input_api_model.py
+++ b/annotell-input-api/annotell/input_api/input_api_model.py
@@ -543,8 +543,8 @@ class Input(Response):
             f"internal_id={self.internal_id}, " + \
             f"external_id={self.external_id}, " + \
             f"input_type={self.input_type}, " + \
-            f"invalidated={self.invalidated}, " + \
-            f"invalidated_reason={self.invalidated_reason})>"
+            f"batch={self.batch}, " + \
+            f"status={self.status})>"
 
 
 class InvalidatedInputsResponse(Response):

--- a/annotell-input-api/annotell/input_api/input_api_model.py
+++ b/annotell-input-api/annotell/input_api/input_api_model.py
@@ -1,10 +1,10 @@
 """API MODEL."""
-from typing import List, Mapping, Dict, Optional, Union
+from typing import List, Mapping, Dict, Optional, Union, Any
 from datetime import datetime
 import dateutil.parser
 
 from .model.abstract_models import RequestCall, Response
-from .model.enums import InputBatchStatus, InvalidatedReasonInput
+from .model.enums import InputBatchStatus, InvalidatedReasonInput, InputStatus
 # To preserve old import statements
 from .model.enums import CameraType
 from .model.calibration import CameraProperty
@@ -135,7 +135,9 @@ class SourceSpecification(RequestCall):
 
 
 class SceneMetaData(RequestCall):
-    def __init__(self, external_id: str, source_specification: Optional[SourceSpecification] = None):
+    def __init__(
+        self, external_id: str, source_specification: Optional[SourceSpecification] = None
+    ):
         self.external_id = external_id
         self.source_specification = source_specification
 
@@ -178,7 +180,7 @@ class TimeSpecification(RequestCall):
 
     def to_dict(self) -> dict:
 
-        as_dict = dict(timeCalibration=self.time_calibration.to_dict())
+        as_dict: Dict[Any, Any] = dict(timeCalibration=self.time_calibration.to_dict())
 
         if self.start_ts:
             as_dict["startTs"] = self.start_ts
@@ -211,7 +213,7 @@ class SlamMetaData(CalibratedSceneMetaData):
                  sequence_id: int,
                  sub_sequence_id: int,
                  settings: Optional[dict] = None):
-        super().__init__(external_id, source_specification, calibration_id)
+        super().__init__(external_id, calibration_id, source_specification)
         self.vehicle_data = vehicle_data
         self.dynamic_objects = dynamic_objects
         self.trajectory = trajectory
@@ -263,7 +265,8 @@ class FilesToUpload(RequestCall):
 
 
 class PoseTransform(RequestCall):
-    def __init__(self, timestamp: int, utc_timestamp: float, position: List[float], rotation_quaternion: List[float]):
+    def __init__(self, timestamp: int, utc_timestamp: float, position: List[float],
+                 rotation_quaternion: List[float]):
         self.timestamp = timestamp
         self.utc_timestamp = utc_timestamp
         self.position = position
@@ -350,9 +353,8 @@ class InputList(Response):
 
 
 class InputBatch(Response):
-    def __init__(self, id: int, project_id: int, external_id: str, title: str, status: InputBatchStatus,  created: datetime, updated: datetime):
-        self.id = id
-        self.project_id = project_id
+    def __init__(self, external_id: str, title: str, status: InputBatchStatus,
+                 created: datetime, updated: datetime):
         self.external_id = external_id
         self.title = title
         self.status = status
@@ -361,12 +363,11 @@ class InputBatch(Response):
 
     @staticmethod
     def from_json(js: dict):
-        return InputBatch(int(js["id"]), int(js["projectId"]), js["externalId"], js["title"], js["status"],
+        return InputBatch(js["externalId"], js["title"], js["status"],
                           ts_to_dt(js["created"]), ts_to_dt(js["updated"]))
 
     def __repr__(self):
         return f"<InputBatch(" + \
-            f"id={self.id}, " + \
             f"project_id={self.project_id}, " + \
             f"external_id={self.external_id}, " + \
             f"title={self.title}, " + \
@@ -376,9 +377,8 @@ class InputBatch(Response):
 
 
 class Project(Response):
-    def __init__(self, id: int, created: datetime, title: str, description: str,
+    def __init__(self, created: datetime, title: str, description: str,
                  deadline: Optional[str], status: str, external_id: str):
-        self.id = id
         self.created = created
         self.title = title
         self.description = description
@@ -388,12 +388,11 @@ class Project(Response):
 
     @staticmethod
     def from_json(js: dict):
-        return Project(int(js["id"]), ts_to_dt(js["created"]), js["title"],
+        return Project(ts_to_dt(js["created"]), js["title"],
                        js["description"], js.get("deadline"), js["status"], js["externalId"])
 
     def __repr__(self):
         return f"<Project(" + \
-            f"id={self.id}, " + \
             f"created={self.created}, " + \
             f"title={self.title}, " + \
             f"description={self.description}, " + \
@@ -417,7 +416,8 @@ class Request(Response):
     @staticmethod
     def from_json(js: dict):
         return Request(int(js["id"]), ts_to_dt(js["created"]), int(js["projectId"]),
-                       js["title"], js["description"], int(js["inputListId"]), int(js["inputBatchId"]), js["externalId"])
+                       js["title"], js["description"], int(js["inputListId"]),
+                       int(js["inputBatchId"]), js["externalId"])
 
     def __repr__(self):
         return f"<Request(" + \
@@ -460,7 +460,7 @@ class InputJob(Response):
     @staticmethod
     def from_json(js: dict):
         return InputJob(int(js["id"]), js["jobId"], js["externalId"], js["filename"],
-                        bool(js["status"]), ts_to_dt(js["added"]), js.get("errorMessage"))
+                        str(js["status"]), ts_to_dt(js["added"]), js.get("errorMessage"))
 
     def __repr__(self):
         return f"<InputJob(" + \
@@ -497,7 +497,7 @@ class Data(Response):
     def from_json(js: dict):
         return Data(
             int(js["id"]),
-            js.get("externalId"),
+            str(js.get("externalId")),
             js.get("source"),
             ts_to_dt(js["created"])
         )
@@ -511,21 +511,31 @@ class Data(Response):
 
 
 class Input(Response):
-    def __init__(self, internal_id: Optional[str], external_id: Optional[str], input_type: str, invalidated: Optional[str], invalidated_reason: Optional[InvalidatedReasonInput]):
+    def __init__(
+        self,
+        internal_id: str,
+        external_id: str,
+        batch: str,
+        input_type: str,
+        status: InputStatus,
+        error_message: Optional[str],
+    ):
         self.internal_id = internal_id
         self.external_id = external_id
+        self.batch = batch
         self.input_type = input_type
-        self.invalidated = invalidated
-        self.invalidated_reason = invalidated_reason
+        self.status = status
+        self.error_message = error_message
 
     @staticmethod
     def from_json(js: dict):
         return Input(
-            js.get("internalId"),
-            js.get("externalId"),
+            js["internalId"],
+            js["externalId"],
+            js["batchId"],
             js["inputType"],
-            js.get("invalidated"),
-            js.get("invalidatedReason")
+            js.get("status"),
+            js.get("errorMessage")
         )
 
     def __repr__(self):
@@ -538,7 +548,8 @@ class Input(Response):
 
 
 class InvalidatedInputsResponse(Response):
-    def __init__(self, invalidated_input_ids: List[int], not_found_input_ids: List[int], already_invalidated_input_ids: List[int]):
+    def __init__(self, invalidated_input_ids: List[int], not_found_input_ids: List[int],
+                 already_invalidated_input_ids: List[int]):
         self.invalidated_input_ids = invalidated_input_ids
         self.not_found_input_ids = not_found_input_ids
         self.already_invalidated_input_ids = already_invalidated_input_ids
@@ -557,7 +568,8 @@ class InvalidatedInputsResponse(Response):
 
 
 class RemovedInputsResponse(Response):
-    def __init__(self, removed_input_ids: List[int], not_found_input_ids: List[int], already_removed_input_ids: List[int]):
+    def __init__(self, removed_input_ids: List[int], not_found_input_ids: List[int],
+                 already_removed_input_ids: List[int]):
         self.removed_input_ids = removed_input_ids
         self.not_found_input_ids = not_found_input_ids
         self.already_removed_input_ids = already_removed_input_ids

--- a/annotell-input-api/annotell/input_api/input_api_model.py
+++ b/annotell-input-api/annotell/input_api/input_api_model.py
@@ -305,7 +305,7 @@ class CalibrationNoContent(Response):
         )
 
     def __repr__(self):
-        return f"<CalibrationWithContent(" + \
+        return f"<CalibrationNoContent(" + \
             f"id={self.id}, " + \
             f"external_id={self.external_id}, " + \
             f"created={self.created})>"
@@ -368,7 +368,6 @@ class InputBatch(Response):
 
     def __repr__(self):
         return f"<InputBatch(" + \
-            f"project_id={self.project_id}, " + \
             f"external_id={self.external_id}, " + \
             f"title={self.title}, " + \
             f"status={self.status}, " + \

--- a/annotell-input-api/annotell/input_api/model/enums.py
+++ b/annotell-input-api/annotell/input_api/model/enums.py
@@ -20,3 +20,13 @@ class InputBatchStatus(str, Enum):
     READY = 'ready'
     INPROGESS = 'in-progress'
     COMPLETED = 'completed'
+
+
+class InputStatus(str, Enum):
+    PROCESSING = "processing"
+    CREATED = "created"
+    FAILED = "failed"
+    INVALIDATED_BROKEN_INPUT = "invalidated:broken-input"
+    INVALIDATED_SLAM_RECORRECTION = "invalidated:slam-rerun"
+    INVALIDATED_DUPLICATE = "invalidated:duplicate"
+    INVALIDATED_INCORRECTLY_CREATED = "invalidated:incorrectly-created"

--- a/annotell-input-api/annotell/input_api/util.py
+++ b/annotell-input-api/annotell/input_api/util.py
@@ -1,0 +1,49 @@
+"""Utility functions for Input API """
+
+import mimetypes
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from PIL import Image as PILImage
+import dateutil.parser
+from urllib3.util import Url, parse_url
+
+
+GCS_SCHEME = "gs"
+
+
+def ts_to_dt(date_string: str) -> datetime:
+    """
+    Parse string datetime into datetime
+    """
+    return dateutil.parser.parse(date_string)
+
+
+def filter_none(js: dict) -> dict:
+    if isinstance(js, Mapping):
+        return {k: filter_none(v) for k, v in js.items() if v is not None}
+    else:
+        return js
+
+
+def get_content_type(filename: str) -> str:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
+    if filename.split(".")[-1] == "csv":
+        content_type = "text/csv"
+    else:
+        content_type = mimetypes.guess_type(filename)[0]
+        content_type = content_type if content_type is not None else 'application/octet-stream'
+    return content_type
+
+
+def get_resource_id(signed_url: str) -> str:
+    url = parse_url(signed_url)
+    resource_id = Url(scheme=GCS_SCHEME, path=url.path)
+    return str(resource_id).replace("///", "//")
+
+
+def get_image_dimensions(image_path: str) -> dict:
+    fi = Path(image_path).expanduser()
+    with PILImage.open(fi) as im:
+        width, height = im.size
+        return {"width": width, "height": height}

--- a/annotell-input-api/setup.py
+++ b/annotell-input-api/setup.py
@@ -41,9 +41,11 @@ setup(
         'click>=7.1.1',
         'Pillow>=7.0.0',
         'requests>=2.23.0',
-        'tabulate>=0.8.7'
+        'tabulate>=0.8.7',
+        'python-dateutil',
+        "dataclasses;python_version<'3.7'"
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     include_package_data=True,
     package_data={
         '': ['*.md', 'LICENSE'],

--- a/docs-src/.gitignore
+++ b/docs-src/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+/node_modules
+
+# Production
+/build
+
+# Generated files
+.docusaurus
+.cache-loader
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
Several unused methods removed to facilitate use of input API

Annoutil has also been simplified to include fewer commands. Now has four commands:
- projects
- inputs
- viewlink
- calibration

also added backporting of dataclasses so that it should work for python 3.6.
I have yet to confirm this..
