### PR TITLE
Int 165

### DIFF
--- a/docs-src/docs/input-api/input_model.md
+++ b/docs-src/docs/input-api/input_model.md
@@ -159,4 +159,4 @@ frames = [frame_1, frame_2, frame_3]
 
 The `frame_id` is expressed as a string and is used to produce a unique identifier for each frame in the list of frames. The `frame_id` is used as a top-level key in the produced annotations, indicating which parts of the complete annotation belong to this specific frame.
 
-A common use case is to have the `frame_id` correspond to the `relative_timestamp`.
+A common use case is to have the `frame_id` correspond to the `relative_timestamp` for each frame.

--- a/docs-src/docs/input-api/input_model.md
+++ b/docs-src/docs/input-api/input_model.md
@@ -1,0 +1,162 @@
+---
+title: Structure
+---
+
+## Different types of inputs
+An Input represents a grouping of sensor data (e.g. camera images, lidar pointclouds) that should be annotated together. Any information necessary to express the relationship between the sensors and their captured data is also present, be it camera resolution, sensor name or the frequency at which the data was recorded at.
+
+There are different input types depending on what kind of sensor(s) are used to represent the contents of the input. For example, if you want to create an input only consisting of data from camera sensors then you would use the input type `Cameras`. Similarly, if you want to create an input consisting of lidar sensors and camera sensors then you would use the input type `LidarsAndCameras`. Additionally, inputs can either be **sequential** or **non-sequential**.
+
+### Sequential vs non-sequential
+Sequential inputs represent a *sequence* of sensor data, whereas non-sequential inputs only contain a single snapshot of sensor data. The sequential relationship is expressed via a sequence of **Frames**, where each **Frame** object contains information related to what kind of sensor data constitues the frame (e.g. which image and/or point cloud is a part of the Frame) as well as a *relative timestamp* that captures where in time (relative to the other frames) the Frame is located.
+
+Non-sequential inputs only express a single snapshot of sensor data. As such, these kinds of inputs only contain a single Frame object and do not require any relative timestamp information.
+
+Sequential input types are easily identified by the suffix `Seq` present in their name. The following input types are currently supported:
+* `Cameras`
+* `LidarsAndCameras`
+* `CamerasSeq`
+* `LidarAndCamerasSeq` 
+
+## Required Fields
+All non-sequential inputs have the following structure
+
+```python
+@dataclass
+class Input():
+    external_id: str
+    frame: Frame
+    sensor_specification: SensorSpecification
+    calibration_id: Optional[str] # Required if using lidar sensors
+```
+
+Sequential inputs are similarly represented, except that they instead contain a list of Frames
+
+```python
+@dataclass
+class InputSeq():
+    external_id: str
+    frames: List[Frame]
+    sensor_specification: SensorSpecification
+    calibration_id: Optional[str] # Required if using lidar sensors
+```
+
+The fields contain all of information required to create the input.
+
+### External Id
+Whenever an input is uploaded it automatically gets an unique UUID, this is used as the primary identifier by Annotell and by all of our internal systems. However, in order to make communication around specific inputs easier we also allow for clients to include any kind of identifier to the input via the external id.
+
+### Sensor Specification
+The sensor specification contains information related to the different camera and/or lidar sensors used for capturing the data present on the input. The sensor specification only requires information regarding the width and height of the different camera sensors used in the input.
+
+The additional fields are optional and relate to specifying the order of the camera sensors and human readable variants of the sensor name (e.g. "Front Camera" instead of "FC").
+
+```python
+@dataclass
+class CameraSettings:
+    width: int
+    height: int
+
+@dataclass
+class SensorSpecification:
+    sensor_settings: Mapping[str, CameraSettings]
+    sensor_to_pretty_name: Optional[Dict[str, str]] = None
+    sensor_order: Optional[List[str]] = None
+```
+
+As an example, let's say we have three different camera sensors `R`, `F` and `L`. The `R` sensor is mounted on the right side of the ego vehicle, the `F` sensor at the front and the `L` sensor to the left. Creating a sensor specification for this scenario would correspond to
+
+```python
+sensor_spec = SensorSpecification(
+    sensor_settings={
+        "R": CameraSettings(width=1080, height=1920),
+        "F": CameraSettings(width=1080, height=1920),
+        "L": CameraSettings(width=1080, height=1920)
+    },
+    sensor_to_pretty_name={
+        "R": "Right Camera",
+        "F": "Front Camera",
+        "L": "Left Camera"
+    },
+    sensor_order=["L", "F", "R"]
+)
+```
+
+The specified `sensor_order` will cause the different camera sensors to be presented in a clockwise manner in the annotation tool (Left -> Front -> Right), while the `sensor_to_pretty_name` parameter will result in the annotation tool showing the human readable version of all the sensor names when changing sensor.
+
+### Calibration Id
+Any input consisting of lidar and camera sensors requires a calibration. The calibration captures the spatial relationship (position and rotation) between the different sensors, as well as different camera specific parameters.
+
+This information is used by the annotation tool to highlight regions in the point cloud visible in the selected camera sensors as well as for projecting information from the pointcloud onto the different camera sensors (points, cuboids etc).
+
+Detailed documentation on how to create calibrations via the API is present in the [Calibration section](calibration).
+
+When including calibration id make sure that all of the sensors present on the input are also present in the calibration as well. If this is not the case the input will not be created and a validation error will be returned by the API.
+
+Inputs without a lidar sensor do not require a calibration.
+
+### Frame (non-sequential inputs)
+The Frame object specifies the binary data to be annotated (.jpg, .png, .las etc) as well as which sensor the data originated from. 
+
+The Frame object is different for each input type since they all support different kinds of sensors, even though the overall structure is the same. 
+
+As an example, let's say we want to create an input consiting of images from three different camera sensors `R`, `F` and `L`. The corresponding binary data is present in the files `img_cam_R.jpg`, `img_cam_F.jpg` and `img_cam_F.jpg`. This would correspond to creating a `Cameras` input.
+
+```python
+cameras_input = Cameras(
+    ...,
+    frame=Frame(
+        images=[
+            Image("img_cam_R.jpg", sensor_name="R"),
+            Image("img_cam_F.jpg", sensor_name="F"),
+            Image("img_cam_L.jpg", sensor_name="L"),
+        ]
+    )
+)
+```
+
+Similarly, if we also had an associated lidar pointcloud from the sensor `VDL-64` and a corresponding binary file `scan_vdl_64.las` we would instead express this as a `LidarsAndCameras` input instead.
+
+```python
+lidars_and_cameras = LidarsAndCameras(
+    ...,
+    frame=Frame(
+        images=[
+            Image("img_cam_R.jpg", sensor_name="R"),
+            Image("img_cam_F.jpg", sensor_name="F"),
+            Image("img_cam_L.jpg", sensor_name="L"),            
+        ],
+        point_clouds=[
+            PointCloud("scan_vdl_64.las", sensor_name="VDL-64")
+        ]
+    )
+
+)
+```
+
+### Frames (sequential inputs)
+Sequential inputs deal with a list of Frame objects instead of a single Frame object. In addition, Frame objects associated with sequential inputs have two additional parameters not present in their non-sequential Frame counterparts: `frame_id` and `relative_timestamp`.
+
+The sequential relationship is expressed via the ordering of the Frame objects in the `frames` list
+
+```python
+frame_1 = Frame(...)
+frame_2 = Frame(...)
+frame_3 = Frame(...)
+frames = [frame_1, frame_2, frame_3]
+```
+
+This representation captures that `frame_1` comes first, then `frame_2` and `frame_3`, but it does not express how much time has passed between the different frames. This information is encoded via the `relative_timestamp` parameter present on each Frame object. The relative timestamp is expressed in milliseconds and describes the relative time between the Frame and the start of the input.
+
+For example, let's say that the sensor data is collected and aggregated at 2Hz. That would then be expressed as 
+
+```python
+frame_1 = Frame(..., relative_timestamp=0)
+frame_2 = Frame(..., relative_timestamp=500)
+frame_3 = Frame(..., relative_timestamp=1000)
+frames = [frame_1, frame_2, frame_3]
+```
+
+The `frame_id` is expressed as a string and is used to produce a unique identifier for each frame in the list of frames. The `frame_id` is used as a top-level key in the produced annotations, indicating which parts of the complete annotation belong to this specific frame.
+
+A common use case is to have the `frame_id` correspond to the `relative_timestamp`.

--- a/docs-src/docs/input-api/inputs/cameras.md
+++ b/docs-src/docs/input-api/inputs/cameras.md
@@ -1,23 +1,11 @@
 ---
 title: Cameras
 ---
-All of the inputs at Annotell consists of one or several **frames** where a frame consists of inputs from several sensors, e.g. cameras or lidars. A `Cameras` input consists of a single frame of camera images, where the frame can contain between 1-8 images from different sensors.
+A `Cameras` input consists of a single frame of camera images, where the frame can contain between 1-8 images from different sensors. For more documentation on what each field corresponds to in the `Cameras` object please check the section related to [Input Overview](/docs/input-api/overview).
 
 ```python reference
 https://github.com/annotell/annotell-python/blob/master/annotell-input-api/examples/cameras.py
 ```
-
-
-
-### SensorSpecification
-The `SensorSpecification` includes the fields `sensor_to_pretty_name`, `sensor_order` and `sensor_settings`, where only the latter is mandatory. Adding information about pretty name and sensor order is useful information during annotation.
-
-| Parameter               | Description                                                                                                  |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `sensor_to_pretty_name` | *(Optional)* A mapping of sensor names to a prettier name version displayed in the Annotell Annotation Tool. |
-| `sensor_order`          | *(Optional)* Defines in what order (left to right) the camera sensors that should be shown in the Annotell Annotation Tool   |
-| `sensor_settings`       | A mapping of a sensor name to a `CameraSettings` object, where the `CameraSettings` object consists of the resolution of the image.                       |
-
 
 :::tip Use dryrun to validate input
 Setting `dryrun` parameter to true in the method call, will validate the input using the Input API but not create any inputs.

--- a/docs-src/docs/input-api/inputs/cameras_seq.md
+++ b/docs-src/docs/input-api/inputs/cameras_seq.md
@@ -2,39 +2,8 @@
 title: CamerasSeq
 ---
 
-A `CamerasSeq` input consists of a sequence of camera images. Unlike single-frame input types you also have to specify the sequential relationship between the _frames_, where each frame consists on 1-8 camera images.
+A `CamerasSeq` input consists of a sequence of camera images, where each frame can contain between 1-8 images from different sensors. For more documentation on what each field corresponds to in the `CamerasSeq` object please check the section related to [Input Overview](/docs/input-api/overview).
 
-## Creating a list of frames
-
-The sequential relationship is expressed via a list of `Frame` objects. This representation expresses the ordering of the frames, but it does not include the _relative temporal_ relationship between the frames in the list.
-
-```python
-frame_1 = IAM.Frame(...)
-frame_2 = IAM.Frame(...)
-frames = [frame_1, frame_2]
-```
-
-In other words, this representation captures that `frame_1` comes before `frame_2`, but does not express how much time has passed between the two frames. In order to express how much time has passed between the frames we need to specify the field `relative_timestamp` for each frame object. If we for example know that we have collected and aggregated our sensor data at 2Hz, then we would express that as
-
-```python
-frame_1 = IAM.Frame(..., relative_timestamp=0)
-frame_2 = IAM.Frame(..., relative_timestamp=500)
-frames = [frame_1, frame_2]
-```
-
-:::tip Why is relative time important?
-Specifying the time relationship between frames is important in order to enable different types of advanced annotator assistance tools in the Annotell platform. These tools enable a **significant** reduction in annotation time, while keeping quality high.
-:::
-
-## Creating the input
-In addition to supplying the sequential and temporal information for our `Frame` objects we also need to specify the camera images that constitute each frame. This is done by passing a list of `ImageFrame` objects, where each of these objects contains the path to the underlying file as well as the sensor name. Finally, we also need to specify the `frame_id` of each frame.
-
-In order to create the input we need to use our list of `Frame` objects and specify the parameters `external_id` and `sensor_specification`.
-
-| Parameter            | Description                                                                                                                                                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| external_id          | Id which can be used to track progress of annotations with.                                                                                                                                                                                                      |
-| sensor_specification | Additional information about sensors, includes `sensor_to_pretty_name` and `sensor_order`. Defines which sensor that should be shown first, the sensor_order, or a mapping of sensor names to a prettier name version displayed in the Annotell Annotation Tool. |
 
 ```python reference
 https://github.com/annotell/annotell-python/blob/master/annotell-input-api/examples/cameras_seq.py

--- a/docs-src/docs/input-api/inputs/cameras_seq.md
+++ b/docs-src/docs/input-api/inputs/cameras_seq.md
@@ -6,7 +6,7 @@ A `CamerasSeq` input consists of a sequence of camera images, where each frame c
 
 
 ```python reference
-https://github.com/annotell/annotell-python/blob/master/annotell-input-api/examples/cameras_seq.py
+https://github.com/annotell/annotell-python/blob/master/annotell-input-api/examples/cameras_seq_images.py
 ```
 
 :::tip Use dryrun to validate input

--- a/docs-src/docs/input-api/inputs/lidars.md
+++ b/docs-src/docs/input-api/inputs/lidars.md
@@ -1,5 +1,0 @@
----
-title: Lidars 🚧
----
-
-Not yet implemented.

--- a/docs-src/docs/input-api/inputs/lidars_and_cameras.md
+++ b/docs-src/docs/input-api/inputs/lidars_and_cameras.md
@@ -2,19 +2,13 @@
 title: LidarsAndCameras
 ---
 
-All of the inputs at Annotell consists of one or several frames where a frame consists of inputs from several sensors, e.g. cameras or lidars. A `LidarsAndCameras` input consists of a *single* frame which contains 1-8 cameras images as well as a single pointcloud.
+A `LidarsAndCameras` input consists of a *single* frame which contains 1-8 cameras images as well as a single pointcloud. For more documentation on what each field corresponds to in the `LidarsAndCameras` object please check the section related to [Input Overview](/docs/input-api/overview).
 
-## Creating the input
-In order to create a `LidarsAndCameras` you need to specify the following parameters
-
-| Parameter            | Description                                                                                                                                                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| external_id          | Id which can be used to track progress of annotations with.                                                                                                                                                                                                      |
-| sensor_specification | Additional information about sensors, includes `sensor_to_pretty_name` and `sensor_order`. Defines which sensor that should be shown first, the sensor_order, or a mapping of sensor names to a prettier name version displayed in the Annotell Annotation Tool. |
-| calibration_id       | Which calibration to use for the input.                            |
-| frame                | Specifies which camera images and lidar pointclouds constitute the frame.                            |
 
 ```python reference
 https://github.com/annotell/annotell-python/blob/master/annotell-input-api/examples/lidars_and_cameras.py
 ```
 
+:::tip Use dryrun to validate input
+Setting `dryrun` parameter to true in the method call, will validate the input using the Input API but not create any inputs.
+:::

--- a/docs-src/docs/input-api/inputs/lidars_and_cameras_seq.md
+++ b/docs-src/docs/input-api/inputs/lidars_and_cameras_seq.md
@@ -2,59 +2,21 @@
 title: LidarsAndCamerasSeq
 ---
 
-A `LidarsAndCamerasSeq` input consists of a sequence of camera images and lidar point clouds. Unlike single-frame input types you also have to specify the sequential relationship between the _frames_, where each frame consists on 1-8 camera images, as well as lidar point clouds.
+A `LidarsAndCamerasSeq` input consists of a sequence of camera images and lidar point clouds, where each frame consists on 1-8 camera images as well as a single cloud. For more documentation on what each field corresponds to in the `LidarsAndCamerasSeq` object please check the section related to [Input Overview](/docs/input-api/overview).
 
 :::info no multi-lidar support currently
 Currently there is only support for supplying a single point cloud per frame.
 :::
 
-## Creating a list of frames
-
-The sequential relationship is expressed via a list of `Frame` objects. This representation expresses the ordering of the frames, but it does not include the _relative temporal_ relationship between the frames in the list.
-
-```python
-frame_1 = IAM.Frame(...)
-frame_2 = IAM.Frame(...)
-frames = [frame_1, frame_2]
-```
-
-In other words, this representation captures that `frame_1` comes before `frame_2`, but does not express how much time has passed between the two frames. In order to express how much time has passed between the frames we need to specify the field `relative_timestamp` for each frame object. If we for example know that we have collected and aggregated our sensor data at 2Hz, then we would express that as
-
-```python
-frame_1 = IAM.Frame(..., relative_timestamp=0)
-frame_2 = IAM.Frame(..., relative_timestamp=500)
-frames = [frame_1, frame_2]
-```
-
-:::tip Why is relative time important?
-Specifying the time relationship between frames is important in order to enable different types of advanced annotator assistance tools in the Annotell platform. These tools enable a **significant** reduction in annotation time, while keeping quality high.
-:::
-
-## Creating the input
-In addition to supplying the sequential and temporal information for our `Frame` objects we also need to specify the camera images and lidar point clouds that constitute each frame. This is done by passing a list of `PointCloudFrame` and `ImageFrame` objects, where each of these objects contains the path to the underlying file as well as the sensor name. Finally, we also need to specify the `frame_id` of each frame.
-
-In order to create the input we need to use our list of `Frame` objects and specify the parameters `external_id` and `calibration_id` as well as the optional parameter `sensor_specification`.
-
-| Parameter            | Description                                                                                                                                                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| external_id          | Id which can be used to track progress of annotations with.                                                                                                                                                                                                      |
-| sensor_specification | Additional information about sensors, includes `sensor_to_pretty_name` and `sensor_order`. Defines which sensor that should be shown first, the sensor_order, or a mapping of sensor names to a prettier name version displayed in the Annotell Annotation Tool. |
-| calibration_id       | Which calibration to use for the input.                            |
-
 ```python reference
 https://github.com/annotell/annotell-python/blob/master/annotell-input-api/examples/lidars_and_cameras_seq.py
 ```
-:::note Be careful with sensor names
-Make sure that the provided sensor names for each image and lidar frame are present in the calibration supplied to the input. Otherwise the input cannot be created. For more information about this see the [Calibration](/input-api/calibration.md) section.
+:::tip Use dryrun to validate input
+Setting `dryrun` parameter to true in the method call, will validate the input using the Input API but not create any inputs.
 :::
-
 
 :::tip reuse calibration
 Note that you can, and should, reuse the same calibration for multiple inputs if possible.
-:::
-
-:::tip Use dryrun to validate input
-Setting `dryrun` parameter to true in the method call, will validate the input using the Input API but not create any inputs.
 :::
 
 

--- a/docs-src/docs/input-api/inputs/lidars_seq.md
+++ b/docs-src/docs/input-api/inputs/lidars_seq.md
@@ -1,5 +1,0 @@
----
-title: LidarsSeq 🚧
----
-
-Not yet implemented.

--- a/docs-src/docs/input-api/overview.md
+++ b/docs-src/docs/input-api/overview.md
@@ -161,7 +161,7 @@ frames = [frame_1, frame_2, frame_3]
 
 The `frame_id` is expressed as a string and is used to produce a unique identifier for each frame in the list of frames. The `frame_id` is used as a top-level key in the produced annotations, indicating which parts of the complete annotation belong to this specific frame.
 
-A common use case is to have the `frame_id` correspond to the `relative_timestamp` for each frame.
+A common use case is to use uuids for each `frame_id`, or a combination of `external_id` and `frame_index`. For example, if the `external_id` of the input is `shanghai_20200101` then the `frame_id` could be encoded as `shanghai_20200101:0` for the first frame, `shanghai_20200101:1` for the second frame and so on.
 
 ## Video or sequence of images for sequential inputs?
 

--- a/docs-src/docs/input-api/overview.md
+++ b/docs-src/docs/input-api/overview.md
@@ -46,7 +46,7 @@ class InputSeq():
 The fields contain all of the information required to create the input.
 
 ### External Id
-Whenever an input is uploaded it automatically gets an unique UUID, this is used as the primary identifier by Annotell and by all of our internal systems. However, in order to make communication around specific inputs easier we also allow for clients to include any kind of identifier to the input via the external id.
+Whenever an input is uploaded it automatically gets an UUID, this is used as the primary identifier by Annotell and by all of our internal systems. However, in order to make communication around specific inputs easier we also allow for clients to include any kind of identifier to the input via the external id.
 
 ### Sensor Specification
 The sensor specification contains information related to the different camera and/or lidar sensors used for capturing the data present on the input. The sensor specification only requires information regarding the width and height of the different camera sensors used in the input.

--- a/docs-src/docs/input-api/usage.md
+++ b/docs-src/docs/input-api/usage.md
@@ -1,5 +1,5 @@
 ---
-title: General
+title: Working with Inputs
 ---
 
 ## Creating Inputs
@@ -146,4 +146,14 @@ client.annotation.get_annotations(input_uuids=[
     'decf6479-d540-459f-b924-a12c2cecf3b5',
     '5da4f44b-16cb-414a-8dbd-ff5e5afc309a'
 ])
+```
+
+A common use case is downloading all completed annotations a project. This can be performed by first fetching all of the inputs added to the project and then filtering to only include inputs with status `"created"` (see [Input Statuses](#input-status)).
+
+```python
+project = "project-identifier"
+inputs = client.input.get_inputs(project=project)
+input_ids = [input.uuid for input in inputs if input.status == "created"]
+annotations = input_api.annotation.get_annotations(input_uuids=input_ids)
+
 ```

--- a/docs-src/docs/input-api/usage.md
+++ b/docs-src/docs/input-api/usage.md
@@ -150,10 +150,6 @@ client.annotation.get_annotations(input_uuids=[
 
 A common use case is downloading all completed annotations a project. This can be performed by first fetching all of the inputs added to the project and then filtering to only include inputs with status `"created"` (see [Input Statuses](#input-status)).
 
-```python
-project = "project-identifier"
-inputs = client.input.get_inputs(project=project)
-input_ids = [input.uuid for input in inputs if input.status == "created"]
-annotations = input_api.annotation.get_annotations(input_uuids=input_ids)
-
+```python reference
+https://github.com/annotell/annotell-python/blob/f2b941373b1dff4297d7705ef0f2587eadbca7b3/annotell-input-api/examples/download_annotations.py#L10-L12
 ```

--- a/docs-src/docs/input-api/usage.md
+++ b/docs-src/docs/input-api/usage.md
@@ -5,7 +5,7 @@ title: Working with Inputs
 ## Creating Inputs
 
 :::note
-For detailed information about different input modalities, check [Cameras](inputs/cameras), [LidarsAndCameras](inputs/lidars_and_cameras) or [LidarsAndCamerasSeq](inputs/lidars_and_cameras_seq).
+For detailed information about different input modalities, check the Input Types section.
 :::
 
 :::tip Annotell Users

--- a/docs-src/docs/key_concepts.md
+++ b/docs-src/docs/key_concepts.md
@@ -70,10 +70,8 @@ Inputs can be created via Annotell's Input API, which has support for several di
 | Type                           | Description                                                                           |
 | -------------------------------|---------------------------------------------------------------------------------------|
 | **Cameras**                    | A single frame consisting of images from 1-8 cameras                                  |
-| **Lidars** 🚧                  | A single frame consisting of 1-3 lidar point clouds                                   |
 | **LidarsAndCameras**           | A single frame consisting of 1-3 lidar point clouds and images from 1-8 cameras       |
-| **CamerasSeq** 🚧              | Sequence of frames, each frame consisting of images from 1-8 cameras                  |
-| **LidarsSeq**                  | Sequence of frames, each frame consisting of 1-3 lidar point clouds                   |
+| **CamerasSeq**                 | Sequence of frames, each frame consisting of images from 1-8 cameras                  |
 | **LidarsAndCamerasSeq**        | Sequence of frames, consisting of 1-3 lidar point clouds and images from 1-8 cameras  |
 
 

--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -6,12 +6,16 @@ module.exports = {
       "input-api/project",
       {"Inputs": [
         "input-api/general",
-        "input-api/inputs/cameras",
-        "input-api/inputs/lidars",
-        "input-api/inputs/lidars_and_cameras",
-        "input-api/inputs/cameras_seq",
-        "input-api/inputs/lidars_seq",
-        "input-api/inputs/lidars_and_cameras_seq"
+        "input-api/input_model",
+        {"Input Types": [
+          "input-api/inputs/cameras",
+          "input-api/inputs/cameras",
+          "input-api/inputs/lidars",
+          "input-api/inputs/lidars_and_cameras",
+          "input-api/inputs/cameras_seq",
+          "input-api/inputs/lidars_seq",
+          "input-api/inputs/lidars_and_cameras_seq"
+        ]},
       ]},
       "input-api/calibration",
       "input-api/error_handling",

--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -5,17 +5,14 @@ module.exports = {
     "Input API": [
       "input-api/project",
       {"Inputs": [
-        "input-api/general",
-        "input-api/input_model",
+        "input-api/overview",
         {"Input Types": [
           "input-api/inputs/cameras",
-          "input-api/inputs/cameras",
-          "input-api/inputs/lidars",
           "input-api/inputs/lidars_and_cameras",
           "input-api/inputs/cameras_seq",
-          "input-api/inputs/lidars_seq",
           "input-api/inputs/lidars_and_cameras_seq"
         ]},
+        "input-api/usage",
       ]},
       "input-api/calibration",
       "input-api/error_handling",


### PR DESCRIPTION
Restructured the documentation.

1. Added a new section called `Overview` which discusses the input format, all the parameters, sequences as well as video vs images. 
2. Renamed the `General` section to `Working with Inputs`, felt like a better name
3. Added an expanded section under `Working with Inputs`->`Downloading Annotations` with example code on how to combine `get_inputs` with `download_annotations`
4. Removed construction-signs and associated input types like `Lidars` and `LidarsSeq` since it's not clear if we'll even have these