### PR TITLE
Changed calibration width/height to match examples

### DIFF
--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -11,6 +11,10 @@ Documentation about how to use the library can found [here](https://annotell.git
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.5] - TBD
+### Changed
+- Changed the image height/width in the example calibration created in the examples to match the image/videos.
+
 ## [1.0.4] - 2021-04-26
 ### Added
 - Added support for providing metadata in the form of a flat KV-pair both on an input-level for all input types, as well as on a frame-level for all sequential input types.

--- a/annotell-input-api/README.md
+++ b/annotell-input-api/README.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.5] - TBD
 ### Changed
-- Changed the image height/width in the example calibration created in the examples to match the image/videos.
+- Changed the height/width in the unity calibration created in the examples to match the image/videos.
 
 ## [1.0.4] - 2021-04-26
 ### Added

--- a/annotell-input-api/annotell/input_api/__init__.py
+++ b/annotell-input-api/annotell/input_api/__init__.py
@@ -3,4 +3,4 @@ from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/annotell-input-api/examples/calibration.py
+++ b/annotell-input-api/examples/calibration.py
@@ -40,8 +40,8 @@ def create_sensor_calibration(external_id, lidar_sources: List[str] = None, came
             camera_matrix=camera_camera_matrix,
             distortion_coefficients=camera_distortion_coefficients,
             camera_properties=camera_properties,
-            image_height=920,
-            image_width=1244
+            image_height=1080,
+            image_width=1920
         )
 
     # Create calibration for the scene


### PR DESCRIPTION
The width/height in the calibration used in the examples didn't match what we use in the examples, causing our async validation to fail so that the inputs are not created.