### PR TITLE
add download annotation by annotation type

### DIFF
--- a/annotell-input-api/annotell/input_api/model/annotation/__init__.py
+++ b/annotell-input-api/annotell/input_api/model/annotation/__init__.py
@@ -1,1 +1,2 @@
-from annotell.input_api.model.annotation.export_annotation import Annotation
+from annotell.input_api.model.annotation.export_annotation import ExportAnnotation
+from annotell.input_api.model.annotation.client_annotation import Annotation

--- a/annotell-input-api/annotell/input_api/model/annotation/client_annotation.py
+++ b/annotell-input-api/annotell/input_api/model/annotation/client_annotation.py
@@ -10,7 +10,7 @@ class Annotation(Response):
     input_uuid: str
     annotation_type: str
     created: datetime
-    annotation: Optional[Dict] = None
+    content: Dict
 
     @staticmethod
     def from_json(js: dict):
@@ -18,5 +18,5 @@ class Annotation(Response):
             input_uuid=js["inputUuid"],
             annotation_type=js["annotationType"],
             created=ts_to_dt(js["created"]),
-            annotation=js.get("annotation")
+            content=js.get("content") or dict()
         )

--- a/annotell-input-api/annotell/input_api/model/annotation/client_annotation.py
+++ b/annotell-input-api/annotell/input_api/model/annotation/client_annotation.py
@@ -1,0 +1,22 @@
+from typing import Optional, Dict
+from datetime import datetime
+from dataclasses import dataclass
+from annotell.input_api.model.abstract.abstract_models import Response
+from annotell.input_api.util import ts_to_dt
+
+
+@dataclass
+class Annotation(Response):
+    input_uuid: str
+    annotation_type: str
+    created: datetime
+    annotation: Optional[Dict] = None
+
+    @staticmethod
+    def from_json(js: dict):
+        return Annotation(
+            input_uuid=js["inputUuid"],
+            annotation_type=js["annotationType"],
+            created=ts_to_dt(js["created"]),
+            annotation=js.get("annotation")
+        )

--- a/annotell-input-api/annotell/input_api/model/annotation/export_annotation.py
+++ b/annotell-input-api/annotell/input_api/model/annotation/export_annotation.py
@@ -4,13 +4,13 @@ from typing import Union
 
 
 @dataclass
-class Annotation(Response):
+class ExportAnnotation(Response):
     annotation_id: int
     export_content: Union[list, dict]
 
     @staticmethod
     def from_json(js: dict):
-        return Annotation(
+        return ExportAnnotation(
             annotation_id=int(js["annotationId"]),
             export_content=js["exportContent"]
         )

--- a/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
+++ b/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
@@ -34,7 +34,7 @@ class AnnotationResource(InputAPIResource):
     def get_project_annotations(self,
                                 project: str,
                                 annotation_type: str,
-                                batch: Optional[str] = None) -> Generator[dict, None, None]:
+                                batch: Optional[str] = None) -> Generator[Annotation, None, None]:
         url = f"v1/annotations/projects/{project}/"
         if batch:
             url += f"batch/{batch}/"
@@ -44,7 +44,9 @@ class AnnotationResource(InputAPIResource):
         annotations = self._client.get(url)
         for js in annotations:
             annotation = Annotation.from_json(js)
-            yield self.get_annotation(annotation.input_uuid, annotation_type)
+            annotation.content = self.get_annotation(annotation.input_uuid, annotation_type)
+
+            yield annotation
 
     def get_annotation(self,
                        input_uuid: str,

--- a/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
+++ b/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
@@ -1,6 +1,6 @@
 from typing import List, Dict, Optional, Generator
 
-import annotell.input_api.model.annotation as AnnotationModel
+from annotell.input_api.model.annotation import ExportAnnotation, Annotation
 from annotell.input_api.util import filter_none
 from annotell.input_api.resources.abstract import InputAPIResource
 
@@ -9,7 +9,7 @@ class AnnotationResource(InputAPIResource):
     def get_annotations(
             self,
             input_uuids: List[str]
-    ) -> Dict[str, List[AnnotationModel.ExportAnnotation]]:
+    ) -> Dict[str, List[ExportAnnotation]]:
         """
         Returns the export ready annotations, either
 
@@ -24,14 +24,14 @@ class AnnotationResource(InputAPIResource):
         annotations = dict()
         for k, v in json_resp.items():
             annotations[k] = [
-                AnnotationModel.ExportAnnotation.from_json(annotation) for annotation in v
+                ExportAnnotation.from_json(annotation) for annotation in v
             ]
         return annotations
 
     def get_project_annotations(self,
                                 project: str,
                                 annotation_type: str,
-                                batch: Optional[str] = None) -> Generator[AnnotationModel.Annotation, None, None]:
+                                batch: Optional[str] = None) -> Generator[dict, None, None]:
         url = f"v1/annotations/projects/{project}/"
         if batch:
             url += f"batch/{batch}/"
@@ -40,7 +40,7 @@ class AnnotationResource(InputAPIResource):
 
         annotations = self._client.get(url)
         for js in annotations:
-            annotation = AnnotationModel.Annotation.from_json(js)
+            annotation = Annotation.from_json(js)
             yield self.get_annotation(annotation.input_uuid, annotation_type)
 
     def get_annotation(self,

--- a/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
+++ b/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
@@ -1,11 +1,14 @@
 from typing import List, Dict, Optional, Generator
-
+from deprecated import deprecated
 from annotell.input_api.model.annotation import ExportAnnotation, Annotation
 from annotell.input_api.util import filter_none
 from annotell.input_api.resources.abstract import InputAPIResource
 
 
 class AnnotationResource(InputAPIResource):
+    @deprecated(reason="Returns annotations in client-specific format."
+                       "This method is deprecated in favour of `get_project_annotations` which lets you list "
+                       "annotations based on project, batch and annotation type.")
     def get_annotations(
             self,
             input_uuids: List[str]

--- a/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
+++ b/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
@@ -38,8 +38,8 @@ class AnnotationResource(InputAPIResource):
         url = f"v1/annotations/projects/{project}/"
         if batch:
             url += f"batch/{batch}/"
-        if annotation_type:
-            url += f"annotation-type/{annotation_type}"
+
+        url += f"annotation-type/{annotation_type}"
 
         annotations = self._client.get(url)
         for js in annotations:

--- a/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
+++ b/annotell-input-api/annotell/input_api/resources/annotation/annotation.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Optional, Generator
 
 import annotell.input_api.model.annotation as AnnotationModel
 from annotell.input_api.util import filter_none
@@ -7,16 +7,13 @@ from annotell.input_api.resources.abstract import InputAPIResource
 
 class AnnotationResource(InputAPIResource):
     def get_annotations(
-        self,
-        input_uuids: List[str]
-    ) -> Dict[str, List[AnnotationModel.Annotation]]:
+            self,
+            input_uuids: List[str]
+    ) -> Dict[str, List[AnnotationModel.ExportAnnotation]]:
         """
         Returns the export ready annotations, either
-        * All annotations connected to a specific request, if a request id is given
-        * All annotations connected to the organization of the user, if no request id is given
 
         :param input_uuids: List with input uuid
-        :param request_id: An id of a request
         :return Dict: A dictionary containing the ready annotations
         """
         external_id_query_param = ",".join(input_uuids) if input_uuids else None
@@ -24,10 +21,30 @@ class AnnotationResource(InputAPIResource):
             "inputs": external_id_query_param
         }))
 
-
         annotations = dict()
         for k, v in json_resp.items():
             annotations[k] = [
-                AnnotationModel.Annotation.from_json(annotation) for annotation in v
+                AnnotationModel.ExportAnnotation.from_json(annotation) for annotation in v
             ]
         return annotations
+
+    def get_project_annotations(self,
+                                project: str,
+                                annotation_type: str,
+                                batch: Optional[str] = None) -> Generator[AnnotationModel.Annotation, None, None]:
+        url = f"v1/annotations/projects/{project}/"
+        if batch:
+            url += f"batch/{batch}/"
+        if annotation_type:
+            url += f"annotation-type/{annotation_type}"
+
+        annotations = self._client.get(url)
+        for js in annotations:
+            annotation = AnnotationModel.Annotation.from_json(js)
+            yield self.get_annotation(annotation.input_uuid, annotation_type)
+
+    def get_annotation(self,
+                       input_uuid: str,
+                       annotation_type: str) -> dict:
+        annotation = self._client.get(f"v1/annotations/inputs/{input_uuid}/annotation-type/{annotation_type}")
+        return annotation


### PR DESCRIPTION
Add support for fetching annotations via project/batch/annotation-type. 

`get_annotations` will return a `Generator[dict]`, meaning that we will yield the annotations and not fetch them in one request. I expect this to be **slow**, but it gives us the flexibility to change the implementation of internal storage.

This way you can either iterate or call `list` on the generator. (Which we need to add a notice on in the docs). 

Further, I expect `get_annotation` to be the primary way of downloading annotations when using callbacks.