### PR TITLE
1.0.X download_annotations is not yet deprecated!

### DIFF
--- a/docs-src/docs/input-api/annotations.md
+++ b/docs-src/docs/input-api/annotations.md
@@ -5,7 +5,7 @@ title: Downloading Annotations
 Annotations are made available for each [input](overview) and [annotation type](annotation_types) as soon as they are quality assured by the Annotell platform. Information about the format can be found in the [Key Concepts](../key_concepts.md#annotation) section.
 
 
-## v1.0.x (Deprecated) 🚨
+## v1.0.x (Will be deprecated) 🚨
 
 Once annotations are available they can be downloaded by supplying a list of `input_uuid`s for the corresponding inputs. A dictonary is returned containing available annotations for each input. Several annotations occur if the project is setup in such a way that each input should be annotated with different annotation types, e.g. Lane Markings and Objects.
 

--- a/docs-src/docs/key_concepts.md
+++ b/docs-src/docs/key_concepts.md
@@ -79,7 +79,7 @@ Inputs can be created via Annotell's Input API, which has support for several di
 
 Inputs are annotated in requests, producing _annotations_. Version v1.0.x provide by default annotations in Annotell's annotation format. Version v1.1.x and above provide annotations in the [ASAM OpenLABEL](https://www.asam.net/project-detail/asam-openlabel-v100/) format.
 
-### v1.0.x Format (Deprecated) 🚨
+### v1.0.x Format (Will be deprecated) 🚨
 The Annotell annotation format is closely linked to the Annotell task definition. The task definition determines what we are expected to save, where properties are stored and what datatype(s) the properties will be. The Annotell annotation format is saved as a JSON file and will be described according to the data types of JSON.
 
 The Annotell annotation is an object with the following top keys:


### PR DESCRIPTION
In the docs it currently says that the annotation models/method related to v.1.0.X are deprecated, but they are not yet! But they will be, might be confusing so I wanted to change it back!