### PR TITLE
Annotell-Auth: Fix compatibility issue with authlib >= 1.0.0. 

### DIFF
--- a/annotell-auth/README.md
+++ b/annotell-auth/README.md
@@ -29,14 +29,17 @@ sess.get("https://api.annotell.com")
 
 ## Changelog
 
-### 1.6 (2021-02-21)
+### 1.7.0 (2022-04-11)
+- Fix compatability issue with authlib >= 1.0.0. Resetting the auth session failed, when the refresh token had expired.   
+
+### 1.6.0 (2021-02-21)
 - Expose underlying `requests.Session` on `FaultTolerantAuthRequestSession`
 - Fix some thread locks
 
-### 1.5 (2020-10-20)
+### 1.5.0 (2020-10-20)
 - Add `FaultTolerantAuthRequestSession` that handles token refresh on long running sessions. 
 
-### 1.4 (2020-04-16)
+### 1.4.0 (2020-04-16)
 - Add support for `auth` parameter, with path to credentials file or `AnnotellCredentials` object
 - Drop support for legacy API token
 

--- a/annotell-auth/annotell/auth/__init__.py
+++ b/annotell-auth/annotell/auth/__init__.py
@@ -3,5 +3,5 @@ from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 

--- a/annotell-auth/setup.py
+++ b/annotell-auth/setup.py
@@ -39,7 +39,7 @@ setup(
     keywords=['API', 'Annotell'],
     install_requires=[
         'requests>=2.20,<3',
-        'authlib>=0.14.1,<1'
+        'authlib>=0.14.1,<1.1'
     ],
     python_requires='~=3.6',
     include_package_data=True,


### PR DESCRIPTION
Resetting the auth session failed, when the refresh token had expired.