### PR TITLE
change timestamp in imu-data from float to long

### DIFF
--- a/annotell-input-api/annotell/input_api/model/ego/imu_data.py
+++ b/annotell-input-api/annotell/input_api/model/ego/imu_data.py
@@ -3,7 +3,6 @@ from annotell.input_api.model.ego.utils import UnixTimestampNs
 
 
 class IMUData(BaseSerializer):
-    # TODO: Check that the following statement is true
     """ Data from the Inertial Measurement Unit, both `position` and `rotation` are with respect to the local
         coordinate system (LCS).
     """

--- a/annotell-input-api/annotell/input_api/model/ego/utils.py
+++ b/annotell-input-api/annotell/input_api/model/ego/utils.py
@@ -1,1 +1,1 @@
-UnixTimestampNs = float  # A unix timestamp measured in nano seconds
+UnixTimestampNs = int  # A unix timestamp measured in nano seconds


### PR DESCRIPTION
We are loosing precision when we are using floats, we should be using integers instead

I have created a branch for the Scala part as well, will link that PR here when I create it
related to: https://annotell.atlassian.net/browse/INT-1125